### PR TITLE
Ability to pass "extra" values

### DIFF
--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchConfigurationTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchConfigurationTest.java
@@ -2,10 +2,11 @@ package io.branch.search;
 
 import android.content.Intent;
 import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import junit.framework.Assert;
 
 /**
  * BranchConfiguration class tests.
@@ -49,5 +50,17 @@ public class BranchConfigurationTest extends BranchTest {
         int flags = Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP;
         config.setLaunchIntentFlags(flags);
         Assert.assertEquals(flags, config.getLaunchIntentFlags());
+    }
+
+    @Test
+    public void testRequestExtras() {
+        BranchConfiguration config = new BranchConfiguration();
+        config.addRequestExtra("foo", "bar");
+        JSONObject object = new JSONObject();
+        config.addConfigurationInfo(object);
+        JSONObject extra = object.optJSONObject(BranchConfiguration.JSONKey.RequestExtra.toString());
+        Assert.assertNotNull(extra);
+        String fooValue = extra.optString("foo");
+        Assert.assertEquals("bar", fooValue);
     }
 }

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
@@ -92,6 +92,23 @@ public class BranchSearchRequestTest {
     }
 
     @Test
+    public void testAddExtra() {
+        BranchSearchRequest request = BranchSearchRequest.Create("Pizza");
+        JSONObject jsonOut = BranchSearchInterface.createPayload(request,
+                new BranchConfiguration());
+
+        // If no extra is present, json should not even have the extra key.
+        Assert.assertFalse(jsonOut.has(BranchDiscoveryRequest.JSONKey.Extra.toString()));
+
+        // If some extra is present, it will be inside a child json object.
+        request.addExtra("theme", "dark");
+        jsonOut = BranchSearchInterface.createPayload(request, new BranchConfiguration());
+        JSONObject extra = jsonOut.optJSONObject(BranchDiscoveryRequest.JSONKey.Extra.toString());
+        Assert.assertNotNull(extra);
+        Assert.assertEquals("dark", extra.optString("theme"));
+    }
+
+    @Test
     public void testOverrideLocale() {
         String testLocale = "xx_YY";
 

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
@@ -92,20 +92,43 @@ public class BranchSearchRequestTest {
     }
 
     @Test
-    public void testAddExtra() {
+    public void testSetExtra() {
         BranchSearchRequest request = BranchSearchRequest.Create("Pizza");
-        JSONObject jsonOut = BranchSearchInterface.createPayload(request,
-                new BranchConfiguration());
+        BranchConfiguration configuration = new BranchConfiguration();
+        JSONObject json;
 
         // If no extra is present, json should not even have the extra key.
-        Assert.assertFalse(jsonOut.has(BranchDiscoveryRequest.JSONKey.Extra.toString()));
+        json = BranchSearchInterface.createPayload(request, configuration);
+        Assert.assertFalse(json.has(BranchDiscoveryRequest.JSONKey.Extra.toString()));
 
         // If some extra is present, it will be inside a child json object.
-        request.addExtra("theme", "dark");
-        jsonOut = BranchSearchInterface.createPayload(request, new BranchConfiguration());
-        JSONObject extra = jsonOut.optJSONObject(BranchDiscoveryRequest.JSONKey.Extra.toString());
+        request.setExtra("theme", "dark");
+        json = BranchSearchInterface.createPayload(request, configuration);
+        JSONObject extra = json.optJSONObject(BranchDiscoveryRequest.JSONKey.Extra.toString());
         Assert.assertNotNull(extra);
         Assert.assertEquals("dark", extra.optString("theme"));
+
+        // If null is passed, the object is cleared.
+        request.setExtra("theme", null);
+        json = BranchSearchInterface.createPayload(request, configuration);
+        Assert.assertFalse(json.has(BranchDiscoveryRequest.JSONKey.Extra.toString()));
+    }
+
+    @Test
+    public void testSetExtra_overridesConfiguration() {
+        BranchConfiguration configuration = new BranchConfiguration();
+        configuration.addRequestExtra("theme", "light");
+        configuration.addRequestExtra("size", "small");
+
+        BranchSearchRequest request = BranchSearchRequest.Create("Pizza");
+        request.setExtra("theme", "dark");
+        JSONObject json = BranchSearchInterface.createPayload(request, configuration);
+        JSONObject extra = json.optJSONObject(BranchDiscoveryRequest.JSONKey.Extra.toString());
+        Assert.assertNotNull(extra);
+
+        // Should override "theme" but leave "size" as is.
+        Assert.assertEquals("dark", extra.optString("theme"));
+        Assert.assertEquals("small", extra.optString("size"));
     }
 
     @Test

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.json.JSONException;
@@ -225,7 +224,7 @@ public class BranchConfiguration {
     /**
      * Adds extra data that will be attached to server requests in form
      * of a key-value pair. If request specific values are passed to
-     * {@link BranchDiscoveryRequest#addExtra(String, Object)}, those values
+     * {@link BranchDiscoveryRequest#setExtra(String, Object)}, those values
      * will override the ones specified here with the same key.
      * @param key a key
      * @param data value

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.json.JSONException;

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -42,7 +42,7 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
     // Longitude for the user
     private double user_longitude;
 
-    private final Map<String, Object> extra_data = new HashMap<>();
+    private final Map<String, Object> extra = new HashMap<>();
 
     /**
      * Private Constructor.
@@ -99,11 +99,12 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * @param data value
      * @return this BranchDiscoveryRequest
      */
+    @SuppressWarnings("WeakerAccess")
     public T setExtra(@NonNull String key, @Nullable Object data) {
         if (data == null) {
-            extra_data.remove(key);
+            extra.remove(key);
         } else {
-            extra_data.put(key, data);
+            extra.put(key, data);
         }
         return (T) this;
     }
@@ -120,12 +121,12 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
             // Add extra data.
             // The JSONObject for this key might already exist because the key is shared
             // between this class and BranchConfiguration.
-            if (!extra_data.keySet().isEmpty()) {
+            if (!extra.keySet().isEmpty()) {
                 JSONObject extraData = jsonObject.optJSONObject(JSONKey.Extra.toString());
                 if (extraData == null) extraData = new JSONObject();
 
-                for (String key : extra_data.keySet()) {
-                    Object value = extra_data.get(key);
+                for (String key : extra.keySet()) {
+                    Object value = extra.get(key);
                     extraData.putOpt(key, value);
                 }
                 jsonObject.putOpt(JSONKey.Extra.toString(), extraData);

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -2,6 +2,7 @@ package io.branch.search;
 
 import android.location.Location;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -94,8 +95,12 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * @param data value
      * @return this BranchDiscoveryRequest
      */
-    public T addExtra(@NonNull String key, @NonNull Object data) {
-        this.extra_data.put(key, data);
+    public T addExtra(@NonNull String key, @Nullable Object data) {
+        if (data == null) {
+            extra_data.remove(key);
+        } else {
+            extra_data.put(key, data);
+        }
         return (T) this;
     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -95,7 +95,7 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * @param data value
      * @return this BranchDiscoveryRequest
      */
-    public T addExtra(@NonNull String key, @Nullable Object data) {
+    public T setExtra(@NonNull String key, @Nullable Object data) {
         if (data == null) {
             extra_data.remove(key);
         } else {

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -1,24 +1,31 @@
 package io.branch.search;
 
 import android.location.Location;
+import android.support.annotation.NonNull;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Request model for Branch Discovery.
  */
+@SuppressWarnings("unchecked")
 public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
 
     enum JSONKey {
         Latitude("user_latitude"),
         Longitude("user_longitude"),
-        Timestamp("utc_timestamp");
+        Timestamp("utc_timestamp"),
+        Extra("extra_data");
 
         JSONKey(String key) {
             _key = key;
         }
 
+        @NonNull
         @Override
         public String toString() {
             return _key;
@@ -32,6 +39,8 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
 
     // Longitude for the user
     private double user_longitude;
+
+    private Map<String, Object> extra_data = new HashMap<>();
 
     /**
      * Private Constructor.
@@ -50,7 +59,7 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
             setLatitude(location.getLatitude());
             setLongitude(location.getLongitude());
         }
-        return (T)this;
+        return (T) this;
     }
 
     /**
@@ -58,9 +67,10 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * @param latitude latitude
      * @return this BranchDiscoveryRequest
      */
+    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
     public T setLatitude(double latitude) {
         this.user_latitude = latitude;
-        return (T)this;
+        return (T) this;
     }
 
     /**
@@ -68,9 +78,22 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * @param longitude latitude
      * @return this BranchDiscoveryRequest
      */
+    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
     public T setLongitude(double longitude) {
         this.user_longitude = longitude;
-        return (T)this;
+        return (T) this;
+    }
+
+    /**
+     * Adds extra data to be passed to server in forms
+     * of a key-value pair.
+     * @param key a key
+     * @param data value
+     * @return this BranchDiscoveryRequest
+     */
+    public T addExtra(@NonNull String key, @NonNull Object data) {
+        this.extra_data.put(key, data);
+        return (T) this;
     }
 
     JSONObject convertToJson(JSONObject jsonObject) {
@@ -81,6 +104,16 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
             // Add the current timestamp.
             Long tsLong = System.currentTimeMillis();
             jsonObject.putOpt(JSONKey.Timestamp.toString(), tsLong);
+
+            // Add extra data.
+            if (!extra_data.keySet().isEmpty()) {
+                JSONObject extraData = new JSONObject();
+                for (String key : extra_data.keySet()) {
+                    Object value = extra_data.get(key);
+                    extraData.putOpt(key, value);
+                }
+                jsonObject.putOpt(JSONKey.Extra.toString(), extraData);
+            }
 
 
         } catch (JSONException ignore) {

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -87,10 +87,14 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
     }
 
     /**
-     * Adds extra data to be passed to server in forms
+     * Adds extra data to be passed to server in form
      * of a key-value pair. This value will override any other value for the
      * same key that was previously set and values that were set at the configuration
      * level using {@link BranchConfiguration#addRequestExtra(String, Object)}.
+     *
+     * Passing null as a value will clear any extra that was previously set in this request
+     * (but not those set at the configuration level).
+     *
      * @param key a key
      * @param data value
      * @return this BranchDiscoveryRequest

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -19,7 +19,8 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
         Latitude("user_latitude"),
         Longitude("user_longitude"),
         Timestamp("utc_timestamp"),
-        Extra("extra_data");
+        /** we want to override the configuration-level extras */
+        Extra(BranchConfiguration.JSONKey.RequestExtra.toString());
 
         JSONKey(String key) {
             _key = key;
@@ -40,7 +41,7 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
     // Longitude for the user
     private double user_longitude;
 
-    private Map<String, Object> extra_data = new HashMap<>();
+    private final Map<String, Object> extra_data = new HashMap<>();
 
     /**
      * Private Constructor.
@@ -86,7 +87,9 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
 
     /**
      * Adds extra data to be passed to server in forms
-     * of a key-value pair.
+     * of a key-value pair. This value will override any other value for the
+     * same key that was previously set and values that were set at the configuration
+     * level using {@link BranchConfiguration#addRequestExtra(String, Object)}.
      * @param key a key
      * @param data value
      * @return this BranchDiscoveryRequest
@@ -106,8 +109,12 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
             jsonObject.putOpt(JSONKey.Timestamp.toString(), tsLong);
 
             // Add extra data.
+            // The JSONObject for this key might already exist because the key is shared
+            // between this class and BranchConfiguration.
             if (!extra_data.keySet().isEmpty()) {
-                JSONObject extraData = new JSONObject();
+                JSONObject extraData = jsonObject.optJSONObject(JSONKey.Extra.toString());
+                if (extraData == null) extraData = new JSONObject();
+
                 for (String key : extra_data.keySet()) {
                     Object value = extra_data.get(key);
                     extraData.putOpt(key, value);

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchResponseParser.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchResponseParser.java
@@ -38,12 +38,16 @@ class BranchResponseParser {
         // Return if request is not succeeded
         if (object.optBoolean(SUCCESS_KEY)) {
             // Parse results
-            parseResultArray(object.optString(REQUEST_ID_KEY), object.optJSONArray(RESULTS_KEY), branchSearchResult);
+            parseResultArray(object.optString(REQUEST_ID_KEY),
+                    object.optJSONArray(RESULTS_KEY),
+                    branchSearchResult);
         }
         return branchSearchResult;
     }
 
-    private static void parseResultArray(String requestID, JSONArray resultsArray, BranchSearchResult branchSearchResult) {
+    private static void parseResultArray(String requestID,
+                                         JSONArray resultsArray,
+                                         BranchSearchResult branchSearchResult) {
         if (resultsArray != null) {
             for (int i = 0; i < resultsArray.length(); i++) {
 
@@ -62,19 +66,29 @@ class BranchResponseParser {
 
                         for (int j = 0; j < rawDeepLinks.length(); j++) {
                             BranchLinkResult link = BranchLinkResult.createFromJson(
-                                    rawDeepLinks.optJSONObject(j), name, store_id, icon_url);
+                                    rawDeepLinks.optJSONObject(j),
+                                    name,
+                                    store_id,
+                                    icon_url);
                             deepLinks.add(link);
                         }
                     }
 
                     BranchLinkResult link = null;
                     if (app_search_link != null) {
-                        link = BranchLinkResult.createFromJson(app_search_link, name, store_id,
+                        link = BranchLinkResult.createFromJson(app_search_link,
+                                name,
+                                store_id,
                                 icon_url);
                     }
 
-                    BranchAppResult appResult = new BranchAppResult(store_id, name, icon_url, link,
-                            rankingHint, score, deepLinks);
+                    BranchAppResult appResult = new BranchAppResult(store_id,
+                            name,
+                            icon_url,
+                            link,
+                            rankingHint,
+                            score,
+                            deepLinks);
                     branchSearchResult.results.add(appResult);
                 }
             }


### PR DESCRIPTION
Adds the ability to pass extra values to servers, on a configuration level (through `BranchConfiguration`) and at request level (through `BranchDiscoveryRequest`).

If a value is set on both configuration and request for the same key, the request overrides the other.

This API addresses the "displayTheme" request but is intentionally abstract to address also any future case where the customer must pass a key-value pair to Branch.