### PR TITLE
Shortcuts

### DIFF
--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.json.JSONException;
@@ -31,6 +32,7 @@ public class BranchConfiguration {
     private String countryCode;
     private int intentFlags = Intent.FLAG_ACTIVITY_NEW_TASK;
     private final Map<String, Object> requestExtra = new HashMap<>();
+    private IBranchShortcutHandler shortcutHandler;
 
     // JSONKeys associated with a Configuration
     enum JSONKey {
@@ -77,6 +79,11 @@ public class BranchConfiguration {
         // Check to see if the configuration already has a valid country code.  Default if not.
         if (TextUtils.isEmpty(countryCode)) {
             this.countryCode = Util.getCountryCode(context);
+        }
+
+        // Check to see if the configuration already has a valid shortcut handler.  Default if not.
+        if (shortcutHandler == null) {
+            this.shortcutHandler = IBranchShortcutHandler.DEFAULT;
         }
 
         return this;
@@ -232,6 +239,27 @@ public class BranchConfiguration {
     @SuppressWarnings("WeakerAccess")
     public void addRequestExtra(@NonNull String key, @NonNull Object data) {
         requestExtra.put(key, data);
+    }
+
+    /**
+     * Override the default shortcut handler to validate and launch Shortcut results.
+     * @param shortcutHandler handler to use, or null to use the default
+     * @return this BranchConfiguration
+     */
+    @NonNull
+    public BranchConfiguration setShortcutHandler(@Nullable IBranchShortcutHandler shortcutHandler) {
+        this.shortcutHandler = shortcutHandler;
+        return this;
+    }
+
+    /**
+     * Returns the shortcut handler.
+     * @see #setShortcutHandler(IBranchShortcutHandler)
+     * @return the shortcut handler
+     */
+    @NonNull
+    public IBranchShortcutHandler getShortcutHandler() {
+        return shortcutHandler;
     }
 
     /**

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
@@ -238,12 +238,13 @@ public class BranchConfiguration {
 
     /**
      * Override the default shortcut handler to validate and launch Shortcut results.
-     * @param shortcutHandler handler to use, or null to use the default
+     * @param shortcutHandler handler to use
      * @return this BranchConfiguration
      */
+    @SuppressWarnings("WeakerAccess")
     @NonNull
-    public BranchConfiguration setShortcutHandler(@Nullable IBranchShortcutHandler shortcutHandler) {
-        this.shortcutHandler = shortcutHandler != null ? shortcutHandler : IBranchShortcutHandler.DEFAULT;
+    public BranchConfiguration setShortcutHandler(@NonNull IBranchShortcutHandler shortcutHandler) {
+        this.shortcutHandler = shortcutHandler;
         return this;
     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
@@ -32,7 +32,7 @@ public class BranchConfiguration {
     private String countryCode;
     private int intentFlags = Intent.FLAG_ACTIVITY_NEW_TASK;
     private final Map<String, Object> requestExtra = new HashMap<>();
-    private IBranchShortcutHandler shortcutHandler;
+    private IBranchShortcutHandler shortcutHandler = IBranchShortcutHandler.DEFAULT;
 
     // JSONKeys associated with a Configuration
     enum JSONKey {
@@ -79,11 +79,6 @@ public class BranchConfiguration {
         // Check to see if the configuration already has a valid country code.  Default if not.
         if (TextUtils.isEmpty(countryCode)) {
             this.countryCode = Util.getCountryCode(context);
-        }
-
-        // Check to see if the configuration already has a valid shortcut handler.  Default if not.
-        if (shortcutHandler == null) {
-            this.shortcutHandler = IBranchShortcutHandler.DEFAULT;
         }
 
         return this;
@@ -248,7 +243,7 @@ public class BranchConfiguration {
      */
     @NonNull
     public BranchConfiguration setShortcutHandler(@Nullable IBranchShortcutHandler shortcutHandler) {
-        this.shortcutHandler = shortcutHandler;
+        this.shortcutHandler = shortcutHandler != null ? shortcutHandler : IBranchShortcutHandler.DEFAULT;
         return this;
     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -283,6 +283,13 @@ public class BranchLinkResult implements Parcelable {
 
         link.click_tracking_url = Util.optString(actionJson, LINK_TRACKING_KEY);
         link.android_shortcut_id = Util.optString(actionJson, LINK_ANDROID_SHORTCUT_ID_KEY);
+        if (TextUtils.isEmpty(link.android_shortcut_id)) {
+            // Try with legacy keys.
+            JSONObject object = actionJson.optJSONObject("android_intent");
+            if (object != null) {
+                link.android_shortcut_id = Util.optString(object, "shortcut_id");
+            }
+        }
         return link;
     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -284,13 +284,17 @@ public class BranchLinkResult implements Parcelable {
 
         link.click_tracking_url = Util.optString(actionJson, LINK_TRACKING_KEY);
         link.android_shortcut_id = Util.optString(actionJson, LINK_ANDROID_SHORTCUT_ID_KEY);
+
+        // TODO REMOVE AFTER SERVER UPDATE
+        // Try to read this value from legacy keys.
         if (TextUtils.isEmpty(link.android_shortcut_id)) {
-            // Try with legacy keys.
             JSONObject object = actionJson.optJSONObject("android_intent");
             if (object != null) {
                 link.android_shortcut_id = Util.optString(object, "shortcut_id");
             }
         }
+
+        // Validate if needed.
         boolean hasShortcut = !TextUtils.isEmpty(link.android_shortcut_id);
         if (hasShortcut) { // Need to validate
             Context appContext = BranchSearch.getInstance().getApplicationContext();

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -174,14 +174,12 @@ public class BranchLinkResult implements Parcelable {
         registerClickEvent();
 
         // 1. Try to open the app as an Android shortcut
-        // If it fails, we want to return an error instead of going on
         boolean success = openAppWithAndroidShortcut(context);
-        if (!success && getAndroidShortcutId() != null) {
-            return new BranchSearchError(BranchSearchError.ERR_CODE.ROUTING_ERR_UNABLE_TO_OPEN_ANDROID_SHORTCUT);
-        }
 
         // 2. Try to open the app directly with URI Scheme
-        success = openAppWithUriScheme(context);
+        if (!success) {
+            success = openAppWithUriScheme(context);
+        }
 
         // 3. If URI Scheme is not working try opening with the web link in browser
         if (!success) {

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -174,12 +174,14 @@ public class BranchLinkResult implements Parcelable {
         registerClickEvent();
 
         // 1. Try to open the app as an Android shortcut
+        // If it fails, we want to return an error instead of going on
         boolean success = openAppWithAndroidShortcut(context);
+        if (!success && getAndroidShortcutId() != null) {
+            return new BranchSearchError(BranchSearchError.ERR_CODE.ROUTING_ERR_UNABLE_TO_OPEN_ANDROID_SHORTCUT);
+        }
 
         // 2. Try to open the app directly with URI Scheme
-        if (!success) {
-            success = openAppWithUriScheme(context);
-        }
+        success = openAppWithUriScheme(context);
 
         // 3. If URI Scheme is not working try opening with the web link in browser
         if (!success) {
@@ -284,16 +286,6 @@ public class BranchLinkResult implements Parcelable {
 
         link.click_tracking_url = Util.optString(actionJson, LINK_TRACKING_KEY);
         link.android_shortcut_id = Util.optString(actionJson, LINK_ANDROID_SHORTCUT_ID_KEY);
-        boolean hasShortcut = !TextUtils.isEmpty(link.android_shortcut_id);
-        if (hasShortcut) { // Need to validate
-            Context appContext = BranchSearch.getInstance().getApplicationContext();
-            IBranchShortcutHandler handler = BranchSearch.getInstance()
-                    .getBranchConfiguration()
-                    .getShortcutHandler();
-            if (!handler.validateShortcut(appContext, link.android_shortcut_id, appStoreId)) {
-                return null;
-            }
-        }
         return link;
     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -1,10 +1,15 @@
 package io.branch.search;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.os.Process;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
@@ -12,6 +17,8 @@ import android.text.TextUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.List;
 
 /**
  * Class for representing a a deep link to content
@@ -29,6 +36,7 @@ public class BranchLinkResult implements Parcelable {
     private static final String LINK_ROUTING_MODE_KEY = "routing_mode";
     private static final String LINK_TRACKING_KEY = "click_tracking_link";
     private static final String LINK_RANKING_HINT_KEY = "ranking_hint";
+    private static final String LINK_ANDROID_SHORTCUT_ID_KEY = "android_shortcut_id";
 
     private String entity_id;
     private String name;
@@ -46,6 +54,7 @@ public class BranchLinkResult implements Parcelable {
     private String web_link;
     private String destination_store_id;
     private String click_tracking_url;
+    private String android_shortcut_id;
 
     private BranchLinkResult() {
     }
@@ -115,6 +124,16 @@ public class BranchLinkResult implements Parcelable {
     }
 
     /**
+     * Returns the shortcut id, or null if this link does not represent an Android launcher shortcut.
+     * To inspect the package, please see {@link #getDestinationPackageName()}.
+     * @return id or null
+     */
+    @Nullable
+    public String getAndroidShortcutId() {
+        return TextUtils.isEmpty(android_shortcut_id) ? null : android_shortcut_id;
+    }
+
+    /**
      * This method allows you to register a click event on the action, which informs Branch
      * which item was clicked, improving the rankings and personalization over time
      */
@@ -159,15 +178,20 @@ public class BranchLinkResult implements Parcelable {
     public BranchSearchError openContent(Context context, boolean fallbackToPlayStore) {
         registerClickEvent();
 
-        // 1. Try to open the app directly with URI Scheme
-        boolean success = openAppWithUriScheme(context);
+        // 1. Try to open the app as an Android shortcut
+        boolean success = false; // openAppWithAndroidShortcut(context);
 
-        // 2. If URI Scheme is not working try opening with the web link in browser
+        // 2. Try to open the app directly with URI Scheme
+        if (!success) {
+            success = openAppWithUriScheme(context);
+        }
+
+        // 3. If URI Scheme is not working try opening with the web link in browser
         if (!success) {
             success = openAppWithWebLink(context);
         }
 
-        // 3. Fallback to the playstore
+        // 4. Fallback to the playstore
         if (!success && fallbackToPlayStore) {
             success = openAppWithPlayStore(context);
         }
@@ -229,7 +253,8 @@ public class BranchLinkResult implements Parcelable {
         return isAppOpened;
     }
 
-    @NonNull
+    @SuppressLint("NewApi")
+    @Nullable
     static BranchLinkResult createFromJson(@NonNull JSONObject actionJson,
                                            @NonNull String appName,
                                            @NonNull String appStoreId,
@@ -253,6 +278,36 @@ public class BranchLinkResult implements Parcelable {
         link.destination_store_id = appStoreId;
 
         link.click_tracking_url = Util.optString(actionJson, LINK_TRACKING_KEY);
+        link.android_shortcut_id = Util.optString(actionJson, LINK_ANDROID_SHORTCUT_ID_KEY);
+        boolean hasShortcut = !TextUtils.isEmpty(link.android_shortcut_id);
+        if (hasShortcut && Build.VERSION.SDK_INT < 25) {
+            return null;
+        }
+        if (hasShortcut) {
+            Context appContext = BranchSearch.getInstance().getApplicationContext();
+            LauncherApps launcherApps = appContext.getSystemService(LauncherApps.class);
+            boolean found = false;
+            try {
+                LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
+                query.setQueryFlags(LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC
+                        | LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST
+                        | LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED);
+                query.setPackage(appStoreId);
+                List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, Process.myUserHandle());
+                if (shortcuts == null) return null;
+                for (ShortcutInfo shortcut : shortcuts) {
+                    if (shortcut.getId().equals(link.android_shortcut_id) && shortcut.isEnabled()) {
+                        found = true;
+                        break;
+                    }
+                }
+            } catch (SecurityException | IllegalStateException e) {
+                // Not a launcher
+            }
+            if (!found) {
+                return null;
+            }
+        }
 
         return link;
     }
@@ -281,6 +336,7 @@ public class BranchLinkResult implements Parcelable {
         dest.writeString(this.web_link);
         dest.writeString(this.destination_store_id);
         dest.writeString(this.click_tracking_url);
+        dest.writeString(this.android_shortcut_id);
     }
 
 
@@ -306,6 +362,7 @@ public class BranchLinkResult implements Parcelable {
         this.web_link = in.readString();
         this.destination_store_id = in.readString();
         this.click_tracking_url = in.readString();
+        this.android_shortcut_id = in.readString();
     }
 
     public static final Creator<BranchLinkResult> CREATOR = new Creator<BranchLinkResult>() {

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -260,8 +260,7 @@ public class BranchLinkResult implements Parcelable {
         return isAppOpened;
     }
 
-    @SuppressLint("NewApi")
-    @Nullable
+    @NonNull
     static BranchLinkResult createFromJson(@NonNull JSONObject actionJson,
                                            @NonNull String appName,
                                            @NonNull String appStoreId,

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -291,6 +291,16 @@ public class BranchLinkResult implements Parcelable {
                 link.android_shortcut_id = Util.optString(object, "shortcut_id");
             }
         }
+        boolean hasShortcut = !TextUtils.isEmpty(link.android_shortcut_id);
+        if (hasShortcut) { // Need to validate
+            Context appContext = BranchSearch.getInstance().getApplicationContext();
+            IBranchShortcutHandler handler = BranchSearch.getInstance()
+                    .getBranchConfiguration()
+                    .getShortcutHandler();
+            if (!handler.validateShortcut(appContext, link.android_shortcut_id, appStoreId)) {
+                return null;
+            }
+        }
         return link;
     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -258,7 +258,8 @@ public class BranchLinkResult implements Parcelable {
         return isAppOpened;
     }
 
-    @NonNull
+    @SuppressLint("NewApi")
+    @Nullable
     static BranchLinkResult createFromJson(@NonNull JSONObject actionJson,
                                            @NonNull String appName,
                                            @NonNull String appStoreId,

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -285,15 +285,6 @@ public class BranchLinkResult implements Parcelable {
         link.click_tracking_url = Util.optString(actionJson, LINK_TRACKING_KEY);
         link.android_shortcut_id = Util.optString(actionJson, LINK_ANDROID_SHORTCUT_ID_KEY);
 
-        // TODO REMOVE AFTER SERVER UPDATE
-        // Try to read this value from legacy keys.
-        if (TextUtils.isEmpty(link.android_shortcut_id)) {
-            JSONObject object = actionJson.optJSONObject("android_intent");
-            if (object != null) {
-                link.android_shortcut_id = Util.optString(object, "shortcut_id");
-            }
-        }
-
         // Validate if needed.
         boolean hasShortcut = !TextUtils.isEmpty(link.android_shortcut_id);
         if (hasShortcut) { // Need to validate

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchResponseParser.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchResponseParser.java
@@ -70,7 +70,9 @@ class BranchResponseParser {
                                     name,
                                     store_id,
                                     icon_url);
-                            deepLinks.add(link);
+                            if (link != null) {
+                                deepLinks.add(link);
+                            }
                         }
                     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchResponseParser.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchResponseParser.java
@@ -70,9 +70,7 @@ class BranchResponseParser {
                                     name,
                                     store_id,
                                     icon_url);
-                            if (link != null) {
-                                deepLinks.add(link);
-                            }
+                            deepLinks.add(link);
                         }
                     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
@@ -31,6 +31,7 @@ public class BranchSearch {
             = new URLConnectionNetworkHandler[Channel.values().length];
 
     private BranchConfiguration branchConfiguration;
+    private Context appContext;
 
 
     // Private Constructor.
@@ -129,6 +130,7 @@ public class BranchSearch {
 
         this.branchConfiguration = (config == null ? new BranchConfiguration() : config);
         this.branchConfiguration.setDefaults(context);
+        this.appContext = context.getApplicationContext();
     }
 
     // Undocumented
@@ -203,6 +205,11 @@ public class BranchSearch {
             }
             return null;
         }
+    }
+
+    @NonNull
+    Context getApplicationContext() {
+        return appContext;
     }
 
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
@@ -31,6 +31,7 @@ public class BranchSearch {
             = new URLConnectionNetworkHandler[Channel.values().length];
 
     private BranchConfiguration branchConfiguration;
+    private Context appContext;
 
 
     // Private Constructor.
@@ -129,6 +130,7 @@ public class BranchSearch {
 
         this.branchConfiguration = (config == null ? new BranchConfiguration() : config);
         this.branchConfiguration.setDefaults(context);
+        this.appContext = context.getApplicationContext();
     }
 
     // Undocumented
@@ -204,4 +206,10 @@ public class BranchSearch {
             return null;
         }
     }
+
+    @NonNull
+    Context getApplicationContext() {
+        return appContext;
+    }
+
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
@@ -31,7 +31,6 @@ public class BranchSearch {
             = new URLConnectionNetworkHandler[Channel.values().length];
 
     private BranchConfiguration branchConfiguration;
-    private Context appContext;
 
 
     // Private Constructor.
@@ -130,7 +129,6 @@ public class BranchSearch {
 
         this.branchConfiguration = (config == null ? new BranchConfiguration() : config);
         this.branchConfiguration.setDefaults(context);
-        this.appContext = context.getApplicationContext();
     }
 
     // Undocumented
@@ -206,10 +204,4 @@ public class BranchSearch {
             return null;
         }
     }
-
-    @NonNull
-    Context getApplicationContext() {
-        return appContext;
-    }
-
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchError.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchError.java
@@ -76,9 +76,6 @@ public class BranchSearchError extends JSONObject {
         /** Unable to open the web url associated with the app. */
         ROUTING_ERR_UNABLE_TO_OPEN_WEB_URL,
 
-        /** Unable to open the Android shortcut associated with the link. */
-        ROUTING_ERR_UNABLE_TO_OPEN_ANDROID_SHORTCUT,
-
         /** Unable to open the Google Play Store for the app. */
         ROUTING_ERR_UNABLE_TO_OPEN_PS,
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchError.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchError.java
@@ -76,6 +76,9 @@ public class BranchSearchError extends JSONObject {
         /** Unable to open the web url associated with the app. */
         ROUTING_ERR_UNABLE_TO_OPEN_WEB_URL,
 
+        /** Unable to open the Android shortcut associated with the link. */
+        ROUTING_ERR_UNABLE_TO_OPEN_ANDROID_SHORTCUT,
+
         /** Unable to open the Google Play Store for the app. */
         ROUTING_ERR_UNABLE_TO_OPEN_PS,
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
@@ -2,16 +2,9 @@ package io.branch.search;
 
 import android.content.Context;
 import android.content.pm.LauncherApps;
-import android.content.pm.ShortcutInfo;
 import android.os.Build;
 import android.os.Process;
 import android.support.annotation.NonNull;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Handles Android's shortcut validation and launch.
@@ -19,16 +12,7 @@ import java.util.Set;
 public interface IBranchShortcutHandler {
 
     /**
-     * Validates the given Android shortcut to understand if it's valid or not.
-     * @param context context
-     * @param id shortcut id
-     * @param packageName package name
-     * @return true if this shortcut should be shown
-     */
-    boolean validateShortcut(@NonNull Context context, @NonNull String id, @NonNull String packageName);
-
-    /**
-     * Launches the given Android shortcut, assuming it was previously validated.
+     * Launches the given Android shortcut.
      * @param context context
      * @param id shortcut id
      * @param packageName package name
@@ -40,41 +24,6 @@ public interface IBranchShortcutHandler {
      * The default shortcut handler.
      */
     IBranchShortcutHandler DEFAULT = new IBranchShortcutHandler() {
-        // Caching values between results of the same query and across queries.
-        // This is important because querying is not so fast.
-        // https://developer.android.com/reference/android/content/pm/LauncherApps.ShortcutQuery
-        private final Map<String, Set<String>> mCache = new HashMap<>();
-
-        @Override
-        public boolean validateShortcut(@NonNull Context context,
-                                        @NonNull String id,
-                                        @NonNull String packageName) {
-            if (Build.VERSION.SDK_INT < 25) return false;
-            if (!mCache.containsKey(id)) {
-                Context appContext = BranchSearch.getInstance().getApplicationContext();
-                LauncherApps launcherApps = appContext.getSystemService(LauncherApps.class);
-                Set<String> ids = new HashSet<>();
-                try {
-                    LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
-                    query.setQueryFlags(LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC
-                            | LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST
-                            | LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED);
-                    query.setPackage(packageName);
-                    List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, Process.myUserHandle());
-                    if (shortcuts != null) {
-                        for (ShortcutInfo shortcut : shortcuts) {
-                            if (shortcut.isEnabled()) ids.add(shortcut.getId());
-                        }
-                    }
-                } catch (SecurityException | IllegalStateException e) {
-                    // Not a launcher
-                }
-                mCache.put(packageName, ids);
-            }
-            //noinspection ConstantConditions
-            return mCache.get(packageName).contains(id);
-        }
-
         @Override
         public boolean launchShortcut(@NonNull Context context,
                                    @NonNull String id,

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
@@ -1,0 +1,93 @@
+package io.branch.search;
+
+import android.content.Context;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
+import android.os.Build;
+import android.os.Process;
+import android.support.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Handles Android's shortcut validation and launch.
+ */
+public interface IBranchShortcutHandler {
+
+    /**
+     * Validates the given Android shortcut to understand if it's valid or not.
+     * @param context context
+     * @param id shortcut id
+     * @param packageName package name
+     * @return true if this shortcut should be shown
+     */
+    boolean validateShortcut(@NonNull Context context, @NonNull String id, @NonNull String packageName);
+
+    /**
+     * Launches the given Android shortcut, assuming it was previously validated.
+     * @param context context
+     * @param id shortcut id
+     * @param packageName package name
+     * @return true if launched correctly
+     */
+    boolean launchShortcut(@NonNull Context context, @NonNull String id, @NonNull String packageName);
+
+    /**
+     * The default shortcut handler.
+     */
+    IBranchShortcutHandler DEFAULT = new IBranchShortcutHandler() {
+        // Caching values between results of the same query and across queries.
+        // This is important because querying is not so fast.
+        // https://developer.android.com/reference/android/content/pm/LauncherApps.ShortcutQuery
+        private final Map<String, Set<String>> mCache = new HashMap<>();
+
+        @Override
+        public boolean validateShortcut(@NonNull Context context,
+                                        @NonNull String id,
+                                        @NonNull String packageName) {
+            if (Build.VERSION.SDK_INT < 25) return false;
+            if (!mCache.containsKey(id)) {
+                Context appContext = BranchSearch.getInstance().getApplicationContext();
+                LauncherApps launcherApps = appContext.getSystemService(LauncherApps.class);
+                Set<String> ids = new HashSet<>();
+                try {
+                    LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
+                    query.setQueryFlags(LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC
+                            | LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST
+                            | LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED);
+                    query.setPackage(packageName);
+                    List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, Process.myUserHandle());
+                    if (shortcuts != null) {
+                        for (ShortcutInfo shortcut : shortcuts) {
+                            if (shortcut.isEnabled()) ids.add(shortcut.getId());
+                        }
+                    }
+                } catch (SecurityException | IllegalStateException e) {
+                    // Not a launcher
+                }
+                mCache.put(packageName, ids);
+            }
+            //noinspection ConstantConditions
+            return mCache.get(packageName).contains(id);
+        }
+
+        @Override
+        public boolean launchShortcut(@NonNull Context context,
+                                   @NonNull String id,
+                                   @NonNull String packageName) {
+            if (Build.VERSION.SDK_INT < 25) return false;
+            try {
+                LauncherApps apps = context.getSystemService(LauncherApps.class);
+                apps.startShortcut(packageName, id, null, null,
+                        Process.myUserHandle());
+                return true;
+            } catch (SecurityException e) {
+                return false;
+            }
+        }
+    };
+}

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
@@ -50,9 +50,8 @@ public interface IBranchShortcutHandler {
                                         @NonNull String id,
                                         @NonNull String packageName) {
             if (Build.VERSION.SDK_INT < 25) return false;
-            if (!mCache.containsKey(id)) {
-                Context appContext = BranchSearch.getInstance().getApplicationContext();
-                LauncherApps launcherApps = appContext.getSystemService(LauncherApps.class);
+            if (!mCache.containsKey(packageName)) {
+                LauncherApps launcherApps = context.getSystemService(LauncherApps.class);
                 try {
                     Set<String> ids = new HashSet<>();
                     LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
@@ -2,9 +2,16 @@ package io.branch.search;
 
 import android.content.Context;
 import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
 import android.os.Build;
 import android.os.Process;
 import android.support.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Handles Android's shortcut validation and launch.
@@ -12,7 +19,16 @@ import android.support.annotation.NonNull;
 public interface IBranchShortcutHandler {
 
     /**
-     * Launches the given Android shortcut.
+     * Validates the given Android shortcut to understand if it's valid or not.
+     * @param context context
+     * @param id shortcut id
+     * @param packageName package name
+     * @return true if this shortcut should be shown
+     */
+    boolean validateShortcut(@NonNull Context context, @NonNull String id, @NonNull String packageName);
+
+    /**
+     * Launches the given Android shortcut, assuming it was previously validated.
      * @param context context
      * @param id shortcut id
      * @param packageName package name
@@ -24,6 +40,41 @@ public interface IBranchShortcutHandler {
      * The default shortcut handler.
      */
     IBranchShortcutHandler DEFAULT = new IBranchShortcutHandler() {
+        // Caching values between results of the same query and across queries.
+        // This is important because querying is not so fast.
+        // https://developer.android.com/reference/android/content/pm/LauncherApps.ShortcutQuery
+        private final Map<String, Set<String>> mCache = new HashMap<>();
+
+        @Override
+        public boolean validateShortcut(@NonNull Context context,
+                                        @NonNull String id,
+                                        @NonNull String packageName) {
+            if (Build.VERSION.SDK_INT < 25) return false;
+            if (!mCache.containsKey(id)) {
+                Context appContext = BranchSearch.getInstance().getApplicationContext();
+                LauncherApps launcherApps = appContext.getSystemService(LauncherApps.class);
+                Set<String> ids = new HashSet<>();
+                try {
+                    LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
+                    query.setQueryFlags(LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC
+                            | LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST
+                            | LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED);
+                    query.setPackage(packageName);
+                    List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, Process.myUserHandle());
+                    if (shortcuts != null) {
+                        for (ShortcutInfo shortcut : shortcuts) {
+                            if (shortcut.isEnabled()) ids.add(shortcut.getId());
+                        }
+                    }
+                } catch (SecurityException | IllegalStateException e) {
+                    // Not a launcher
+                }
+                mCache.put(packageName, ids);
+            }
+            //noinspection ConstantConditions
+            return mCache.get(packageName).contains(id);
+        }
+
         @Override
         public boolean launchShortcut(@NonNull Context context,
                                    @NonNull String id,

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
@@ -53,8 +53,8 @@ public interface IBranchShortcutHandler {
             if (!mCache.containsKey(id)) {
                 Context appContext = BranchSearch.getInstance().getApplicationContext();
                 LauncherApps launcherApps = appContext.getSystemService(LauncherApps.class);
-                Set<String> ids = new HashSet<>();
                 try {
+                    Set<String> ids = new HashSet<>();
                     LauncherApps.ShortcutQuery query = new LauncherApps.ShortcutQuery();
                     query.setQueryFlags(LauncherApps.ShortcutQuery.FLAG_MATCH_DYNAMIC
                             | LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST
@@ -66,19 +66,23 @@ public interface IBranchShortcutHandler {
                             if (shortcut.isEnabled()) ids.add(shortcut.getId());
                         }
                     }
-                } catch (SecurityException | IllegalStateException e) {
-                    // Not a launcher
+                    mCache.put(packageName, ids);
+                } catch (Exception e) {
+                    // Not a launcher, not installed, invalid, ....
                 }
-                mCache.put(packageName, ids);
             }
-            //noinspection ConstantConditions
-            return mCache.get(packageName).contains(id);
+            if (mCache.containsKey(packageName)) {
+                //noinspection ConstantConditions
+                return mCache.get(packageName).contains(id);
+            } else {
+                return false;
+            }
         }
 
         @Override
         public boolean launchShortcut(@NonNull Context context,
-                                   @NonNull String id,
-                                   @NonNull String packageName) {
+                                      @NonNull String id,
+                                      @NonNull String packageName) {
             if (Build.VERSION.SDK_INT < 25) return false;
             try {
                 LauncherApps apps = context.getSystemService(LauncherApps.class);

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
@@ -34,7 +34,7 @@ public interface IBranchShortcutHandler {
                 apps.startShortcut(packageName, id, null, null,
                         Process.myUserHandle());
                 return true;
-            } catch (SecurityException e) {
+            } catch (Exception e) {
                 return false;
             }
         }


### PR DESCRIPTION
Goals:
- Open vulcan shortcuts when we have enough permissions
- Offer an API (`IBranchShortcutHandler`) for OEMs to use this feature outside of the launcher

Testing:
Please use `shortcuts-launcher` branch. It bumps version to enable this type of results, plus it registers the demo app as a launcher. Once set as default launcher ("Use always"), results should start appearing.