### PR TITLE
Add BranchLinkResult.isAd()

### DIFF
--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkResultTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkResultTest.java
@@ -1,0 +1,44 @@
+package io.branch.search;
+
+import android.content.Intent;
+import android.os.Parcel;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * BranchLinkResult class tests.
+ */
+@RunWith(AndroidJUnit4.class)
+public class BranchLinkResultTest extends BranchTest {
+
+    @Test
+    public void testParcelable_keepsEmptyStrings() {
+        // Create a BranchLinkResult that's as empty as possible - from empty JSON
+        JSONObject empty = new JSONObject();
+        BranchLinkResult link1 = BranchLinkResult.createFromJson(empty,
+                "appName", "appStoreId", "appIconUrl");
+        Assert.assertNotNull(link1);
+
+        // Ensure missing fields are actually ""s, and the others were correctly set.
+        Assert.assertEquals("", link1.getRankingHint());
+        Assert.assertEquals("appName", link1.getAppName());
+        Assert.assertEquals("appStoreId", link1.getDestinationPackageName());
+        Assert.assertEquals("appIconUrl", link1.getAppIconUrl());
+
+        // Parcel and unparcel.
+        Parcel parcel = Parcel.obtain();
+        link1.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        BranchLinkResult link2 = BranchLinkResult.CREATOR.createFromParcel(parcel);
+
+        // Ensure read fields are what we'd expect.
+        Assert.assertEquals("", link2.getRankingHint());
+        Assert.assertEquals("appName", link2.getAppName());
+        Assert.assertEquals("appStoreId", link2.getDestinationPackageName());
+        Assert.assertEquals("appIconUrl", link2.getAppIconUrl());
+    }
+}

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchAppResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchAppResult.java
@@ -3,6 +3,7 @@ package io.branch.search;
 import android.content.Context;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +23,7 @@ public class BranchAppResult implements Parcelable {
 
     BranchAppResult(String appStoreID, String appName, String appIconUrl,
                     BranchLinkResult searchDeepLink,
-                    String rankingHint,
+                    @NonNull String rankingHint,
                     float score,
                     ArrayList<BranchLinkResult> deep_links) {
         this.app_store_id = appStoreID;
@@ -58,8 +59,18 @@ public class BranchAppResult implements Parcelable {
     /**
      * @return the Ranking Hint.
      */
+    @NonNull
     public String getRankingHint() {
         return this.ranking_hint;
+    }
+
+    /**
+     * Returns true if this link represents an ad.
+     * @return true if ad, false otherwise
+     */
+    @SuppressWarnings("unused")
+    public boolean isAd() {
+        return ranking_hint.toLowerCase().startsWith("featured");
     }
 
     /**

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -90,6 +90,7 @@ public class BranchLinkResult implements Parcelable {
         return metadata;
     }
 
+    @NonNull
     public String getRankingHint() {
         return ranking_hint;
     }
@@ -98,6 +99,7 @@ public class BranchLinkResult implements Parcelable {
      * Returns true if this link represents an ad.
      * @return true if ad, false otherwise
      */
+    @SuppressWarnings("unused")
     public boolean isAd() {
         return ranking_hint.toLowerCase().startsWith("featured");
     }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -284,6 +284,7 @@ public class BranchLinkResult implements Parcelable {
         link.app_icon_url = appIconUrl;
         link.ranking_hint = Util.optString(actionJson, LINK_RANKING_HINT_KEY);
         link.metadata = actionJson.optJSONObject(LINK_METADATA_KEY);
+        if (link.metadata == null) link.metadata = new JSONObject();
 
         link.routing_mode = Util.optString(actionJson, LINK_ROUTING_MODE_KEY);
         link.uri_scheme = Util.optString(actionJson, LINK_URI_SCHEME_KEY);
@@ -345,12 +346,12 @@ public class BranchLinkResult implements Parcelable {
         this.image_url = in.readString();
         this.app_name = in.readString();
         this.app_icon_url = in.readString();
+        this.ranking_hint = in.readString();
         try {
             this.metadata = new JSONObject(in.readString());
         } catch (JSONException e) {
             this.metadata = new JSONObject();
         }
-        this.ranking_hint = in.readString();
 
         this.routing_mode = in.readString();
         this.uri_scheme = in.readString();

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -94,6 +94,14 @@ public class BranchLinkResult implements Parcelable {
         return ranking_hint;
     }
 
+    /**
+     * Returns true if this link represents an ad.
+     * @return true if ad, false otherwise
+     */
+    public boolean isAd() {
+        return ranking_hint.toLowerCase().startsWith("featured");
+    }
+
     public String getRoutingMode() {
         return routing_mode;
     }


### PR DESCRIPTION
Using startsWith() as it seems more future-proof, but I can revert to equals().