### PR TITLE
New location APIs

### DIFF
--- a/BranchSearchDemo/src/main/java/io/branch/search/demo/HomeActivity.java
+++ b/BranchSearchDemo/src/main/java/io/branch/search/demo/HomeActivity.java
@@ -88,19 +88,29 @@ public class HomeActivity extends AppCompatActivity implements BFSearchBox.IKeyw
     @Override
     public void onKeywordChanged(String keyword) {
         if (!TextUtils.isEmpty(keyword)) {
-            // Obtain the last known location before searching.  Use mocks if available.
-            Location location = BranchLocationFinder.getLastKnownLocation();
+            BranchSearch search = BranchSearch.getInstance();
+
+            // Obtain the last known location before searching, using mocks if available.
+            // NOTE: There's no need to apply it before each query. We do so to support mock
+            // locations in this demo app. For real apps, just pass locations to BranchSearch
+            // as soon as you get them from your location component!
+            Location location;
             if (BranchPreferenceActivity.useMockLocation(this)) {
                 location = BranchPreferenceActivity.getMockLocation(this);
                 Log.d(TAG, "Using Mock Location: " + location.toString());
+            } else {
+                location = BranchLocationFinder.getLastKnownLocation();
+            }
+            if (location != null) {
+                search.setLocation(location.getLatitude(), location.getLongitude());
             }
 
+
             // Create a Branch Search Request for the keyword
-            BranchSearchRequest request = BranchSearchRequest.Create(keyword)
-                    .setLocation(location);
+            BranchSearchRequest request = BranchSearchRequest.Create(keyword);
 
             // Search for the keyword with the Branch Search SDK
-            BranchSearch.getInstance().query(request, new IBranchSearchEvents() {
+            search.query(request, new IBranchSearchEvents() {
                 @Override
                 public void onBranchSearchResult(BranchSearchResult result) {
                     // Update UI with search results. BranchSearchResult contains the result of any search.
@@ -120,7 +130,7 @@ public class HomeActivity extends AppCompatActivity implements BFSearchBox.IKeyw
             });
 
             // Get Autosuggestions (Log them only)
-            BranchSearch.getInstance().autoSuggest(request, new IBranchQueryResults() {
+            search.autoSuggest(request, new IBranchQueryResults() {
                 @Override
                 public void onQueryResult(final BranchQueryResult result) {
                     Log.d("Branch", "onAutoSuggest: " + result.getQueryResults().toString());

--- a/BranchSearchSDK/src/androidTest/AndroidManifest.xml
+++ b/BranchSearchSDK/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.branch.search">
+    package="io.branch.search"
+    android:versionCode="1"
+    android:versionName="1.0.0">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchHammerTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchHammerTest.java
@@ -29,8 +29,6 @@ public class BranchHammerTest extends BranchTest {
     private static BranchSearchRequest createTestRequest(String query) {
         BranchSearchRequest request = BranchSearchRequest.Create(query);
 
-        request.setLatitude(19.042813);
-        request.setLongitude(72.840779);
         request.setMaxAppResults(100);
         request.setMaxContentPerAppResults(200);
         request.disableQueryModification();
@@ -201,6 +199,7 @@ public class BranchHammerTest extends BranchTest {
 
     private void initializeAndWarmUp() throws Throwable {
         initBranch(createTestConfiguration());
+        BranchSearch.getInstance().setLocation(19.042813, 72.840779);
         Thread.sleep(10);
 
         // Warm-up the threads

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
@@ -16,8 +16,6 @@ public class BranchQueryHintRequestTest {
     @Test
     public void testRequestCreation() throws Throwable {
         BranchQueryHintRequest requestIn = BranchQueryHintRequest.Create();
-        requestIn.setLatitude(10);
-        requestIn.setLongitude(20);
 
         BranchConfiguration config = new BranchConfiguration();
         config.setBranchKey("key_live_123"); // need a "valid" key
@@ -28,9 +26,6 @@ public class BranchQueryHintRequestTest {
         JSONObject jsonIn = BranchSearchInterface.createPayload(requestIn, config, info);
 
         Log.d("Branch", "QueryHint::testRequestCreation(): " + jsonIn.toString());
-
-        Assert.assertEquals(jsonIn.getInt(BranchDiscoveryRequest.JSONKey.Latitude.toString()), 10);
-        Assert.assertEquals(jsonIn.getInt(BranchDiscoveryRequest.JSONKey.Longitude.toString()), 20);
 
         Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.BranchKey.toString()), "key_live_123");
         Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.Country.toString()), "ZZ");

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
@@ -22,8 +22,6 @@ public class BranchSearchRequestTest {
     public void testRequestCreation() throws Throwable {
         BranchSearchRequest requestIn = BranchSearchRequest.Create("餐厅");
 
-        requestIn.setLatitude(10);
-        requestIn.setLongitude(20);
         requestIn.setMaxAppResults(100);
         requestIn.setMaxContentPerAppResults(200);
         requestIn.disableQueryModification();
@@ -46,9 +44,6 @@ public class BranchSearchRequestTest {
         Assert.assertTrue(jsonIn.getBoolean(BranchSearchRequest.JSONKey.DoNotModify.toString()));
         Assert.assertEquals(BranchQuerySource.QUERY_HINT_RESULTS.toString(),
                 jsonIn.getString(BranchSearchRequest.JSONKey.QuerySource.toString()));
-
-        Assert.assertEquals(10, jsonIn.getInt(BranchDiscoveryRequest.JSONKey.Latitude.toString()));
-        Assert.assertEquals(20, jsonIn.getInt(BranchDiscoveryRequest.JSONKey.Longitude.toString()));
 
         Assert.assertEquals("key_live_123", jsonIn.getString(BranchConfiguration.JSONKey.BranchKey.toString()));
         Assert.assertEquals("ZZ", jsonIn.getString(BranchConfiguration.JSONKey.Country.toString()));

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchTest.java
@@ -92,7 +92,7 @@ public class BranchTest {
         return mContext;
     }
 
-    private Context getUIContext() {
+    Context getUIContext() {
         return mActivity;
     }
 }

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchTest.java
@@ -92,7 +92,7 @@ public class BranchTest {
         return mContext;
     }
 
-    Context getUIContext() {
+    private Context getUIContext() {
         return mActivity;
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDeviceInfo.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDeviceInfo.java
@@ -120,7 +120,7 @@ class BranchDeviceInfo {
         // Check for app version and package.
         appPackage = context.getPackageName();
         try {
-            PackageInfo info = context.getPackageManager().getPackageInfo(appPackage, PackageManager.GET_CONFIGURATIONS | PackageManager.GET_META_DATA);
+            PackageInfo info = context.getPackageManager().getPackageInfo(appPackage, 0);
             appVersion = info.versionName;
         } catch (PackageManager.NameNotFoundException ignore) {
             // Can't happen.

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -17,8 +17,6 @@ import java.util.Map;
 public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
 
     enum JSONKey {
-        Latitude("user_latitude"),
-        Longitude("user_longitude"),
         Timestamp("utc_timestamp"),
         /** we want to override the configuration-level extras */
         Extra(BranchConfiguration.JSONKey.RequestExtra.toString());
@@ -36,12 +34,6 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
         private String _key;
     }
 
-    // Latitude of the user
-    private double user_latitude;
-
-    // Longitude for the user
-    private double user_longitude;
-
     private final Map<String, Object> extra = new HashMap<>();
 
     /**
@@ -52,10 +44,12 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
 
     /**
      * Set the current location.
-     * Branch Search needs location permission for better search experience.  Call this method when location updates happen.
      * @param location Location
      * @return this BranchDiscoveryRequest
+     * @deprecated please use {@link BranchSearch#setLocation(double, double)} instead
      */
+    @SuppressWarnings("deprecation")
+    @Deprecated
     public T setLocation(Location location) {
         if (location != null) {
             setLatitude(location.getLatitude());
@@ -68,10 +62,13 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * Set the current location - latitude.
      * @param latitude latitude
      * @return this BranchDiscoveryRequest
+     * @deprecated please use {@link BranchSearch#setLocation(double, double)} instead
      */
-    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
+    @Deprecated
+    @SuppressWarnings("UnusedReturnValue")
     public T setLatitude(double latitude) {
-        this.user_latitude = latitude;
+        BranchSearch search = BranchSearch.getInstance();
+        if (search != null) search.getBranchDeviceInfo().latitude = latitude;
         return (T) this;
     }
 
@@ -79,10 +76,13 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * Set the current location - longitude.
      * @param longitude latitude
      * @return this BranchDiscoveryRequest
+     * @deprecated please use {@link BranchSearch#setLocation(double, double)} instead
      */
-    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
+    @Deprecated
+    @SuppressWarnings("UnusedReturnValue")
     public T setLongitude(double longitude) {
-        this.user_longitude = longitude;
+        BranchSearch search = BranchSearch.getInstance();
+        if (search != null) search.getBranchDeviceInfo().longitude = longitude;
         return (T) this;
     }
 
@@ -111,9 +111,6 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
 
     JSONObject convertToJson(JSONObject jsonObject) {
         try {
-            jsonObject.putOpt(JSONKey.Latitude.toString(), user_latitude);
-            jsonObject.putOpt(JSONKey.Longitude.toString(), user_longitude);
-
             // Add the current timestamp.
             Long tsLong = System.currentTimeMillis();
             jsonObject.putOpt(JSONKey.Timestamp.toString(), tsLong);

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
@@ -187,4 +187,14 @@ public class BranchSearch {
         return appContext;
     }
 
+    /**
+     * Sets the location that will be appended to all search, query hint and autosuggest requests
+     * triggered by the SDK.
+     * @param latitude user latitude
+     * @param longitude user longitude
+     */
+    public void setLocation(double latitude, double longitude) {
+        branchDeviceInfo.latitude = latitude;
+        branchDeviceInfo.longitude = longitude;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ we have provided example code that fetches the device's last known location.
 ```java
     // Create a Branch Search Request for the keyword
     // Implementation Note:  Set the last known location before searching.
-    BranchSearchRequest request = BranchSearchRequest.Create(keyword)
+    BranchSearchRequest request = BranchSearchRequest.Create(keyword);
 
     // Search for the keyword with the Branch Search SDK
     BranchSearch.getInstance().query(request, new IBranchSearchEvents() {

--- a/README.md
+++ b/README.md
@@ -134,14 +134,17 @@ As a user is typing, Auto Suggest (sometimes referred to as autocomplete) will r
 
 When a user begins typing into your search box, you should create a `BranchSearchRequest` to search for apps and content with Branch. Create a builder for each phrase you would like to search for. Don't worry, we handle debounce so feel free to create one with every character entered.
 
-**Note** that the Branch Discovery SDK will provide better results if it can use the current location. For example, a user searching for a restaurant will receive location specific results if location permissions are enabled. Be sure to add the last known location to the BranchSearchRequest via `setLocation()` or both `setLatitude()` and `setLongitude()`. For your reference, in `io.branch.search.demo.util.BranchLocationFinder`, 
+**Note** that the Branch Discovery SDK will provide better results if
+it can use the current location. For example, a user searching for a
+restaurant will receive location specific results if location permissions
+are enabled. Be sure to pass the user location to `BranchSearch.getInstance().setLocation()`!
+For your reference, in `io.branch.search.demo.util.BranchLocationFinder`,
 we have provided example code that fetches the device's last known location. 
 
 ```java
     // Create a Branch Search Request for the keyword
     // Implementation Note:  Set the last known location before searching.
     BranchSearchRequest request = BranchSearchRequest.Create(keyword)
-            .setLocation(BranchLocationFinder.getLastKnownLocation());
 
     // Search for the keyword with the Branch Search SDK
     BranchSearch.getInstance().query(request, new IBranchSearchEvents() {


### PR DESCRIPTION
- Deprecate `BranchSearchRequest.setLocation()`, setLatitude(), setLongitude(). Adding location to every request adds little value and users can (do...) easily forget to do so, because they have to add one for Search requests, AS and QH requests separately.
- Instead, add global, unified endpoint `BranchSearch.setLocation(double, double)`. This way users can pass the location to branch as soon as they get it instead of having to store the "last known location" and then apply it at query-time.
- Add `BranchDeviceInfo` tests.
- Small changes to demo app to use new API. 