### PR TITLE
Refactor SDK inputs

### DIFF
--- a/BranchSearchDemo/src/main/java/io/branch/search/demo/HomeActivity.java
+++ b/BranchSearchDemo/src/main/java/io/branch/search/demo/HomeActivity.java
@@ -20,6 +20,8 @@ import android.widget.Toast;
 import java.util.List;
 import java.util.Random;
 
+import io.branch.search.BranchAutoSuggestRequest;
+import io.branch.search.BranchQueryHintRequest;
 import io.branch.search.BranchQueryResult;
 import io.branch.search.BranchSearch;
 import io.branch.search.BranchSearchError;
@@ -106,10 +108,9 @@ public class HomeActivity extends AppCompatActivity implements BFSearchBox.IKeyw
             }
 
 
-            // Create a Branch Search Request for the keyword
+            // Create a Branch Search Request for the keyword and
+            // search for the keyword with the Branch Search SDK
             BranchSearchRequest request = BranchSearchRequest.create(keyword);
-
-            // Search for the keyword with the Branch Search SDK
             search.query(request, new IBranchSearchEvents() {
                 @Override
                 public void onBranchSearchResult(BranchSearchResult result) {
@@ -130,7 +131,8 @@ public class HomeActivity extends AppCompatActivity implements BFSearchBox.IKeyw
             });
 
             // Get Autosuggestions (Log them only)
-            search.autoSuggest(request, new IBranchQueryResults() {
+            BranchAutoSuggestRequest autoSuggestRequest = BranchAutoSuggestRequest.create(keyword);
+            search.autoSuggest(autoSuggestRequest, new IBranchQueryResults() {
                 @Override
                 public void onQueryResult(final BranchQueryResult result) {
                     Log.d("Branch", "onAutoSuggest: " + result.getQueryResults().toString());
@@ -203,7 +205,9 @@ public class HomeActivity extends AppCompatActivity implements BFSearchBox.IKeyw
     }
 
     private void fetchQueryHints() {
-        BranchSearch.getInstance().queryHint(new IBranchQueryResults() {
+        BranchQueryHintRequest request = BranchQueryHintRequest.create();
+        request.setMaxResults(6);
+        BranchSearch.getInstance().queryHint(request, new IBranchQueryResults() {
 
             @Override
             public void onQueryResult(final BranchQueryResult result) {
@@ -228,7 +232,6 @@ public class HomeActivity extends AppCompatActivity implements BFSearchBox.IKeyw
                 }
             }
         });
-
     }
 
     private synchronized void updateQueryHint() {

--- a/BranchSearchDemo/src/main/java/io/branch/search/demo/HomeActivity.java
+++ b/BranchSearchDemo/src/main/java/io/branch/search/demo/HomeActivity.java
@@ -107,7 +107,7 @@ public class HomeActivity extends AppCompatActivity implements BFSearchBox.IKeyw
 
 
             // Create a Branch Search Request for the keyword
-            BranchSearchRequest request = BranchSearchRequest.Create(keyword);
+            BranchSearchRequest request = BranchSearchRequest.create(keyword);
 
             // Search for the keyword with the Branch Search SDK
             search.query(request, new IBranchSearchEvents() {

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchAutoSuggestRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchAutoSuggestRequestTest.java
@@ -1,0 +1,31 @@
+package io.branch.search;
+
+import android.support.annotation.NonNull;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * {@link BranchAutoSuggestRequest} tests.
+ */
+@RunWith(AndroidJUnit4.class)
+public class BranchAutoSuggestRequestTest extends BranchDiscoveryRequestTest {
+
+    @NonNull
+    @Override
+    protected BranchDiscoveryRequest newRequest() {
+        return BranchAutoSuggestRequest.create("pizza");
+    }
+
+    @Test
+    public void testQuery() throws Throwable {
+        BranchAutoSuggestRequest request = BranchAutoSuggestRequest.create("foo");
+        BranchConfiguration config = new BranchConfiguration();
+        BranchDeviceInfo info = new BranchDeviceInfo();
+        JSONObject json = BranchSearchInterface.createPayload(request, config, info);
+        Assert.assertEquals("foo", json.getString(BranchAutoSuggestRequest.KEY_USER_QUERY));
+    }
+}

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchAutoSuggestRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchAutoSuggestRequestTest.java
@@ -28,4 +28,19 @@ public class BranchAutoSuggestRequestTest extends BranchDiscoveryRequestTest {
         JSONObject json = BranchSearchInterface.createPayload(request, config, info);
         Assert.assertEquals("foo", json.getString(BranchAutoSuggestRequest.KEY_USER_QUERY));
     }
+
+    @Test
+    public void testMaxResults() throws Throwable {
+        BranchAutoSuggestRequest requestIn = BranchAutoSuggestRequest.create("foo");
+        BranchConfiguration config = new BranchConfiguration();
+        BranchDeviceInfo info = new BranchDeviceInfo();
+
+        requestIn.setMaxResults(12);
+        JSONObject json = BranchSearchInterface.createPayload(requestIn, config, info);
+        Assert.assertEquals(12, json.getInt(BranchAutoSuggestRequest.KEY_MAX_RESULTS));
+
+        requestIn.setMaxResults(-1);
+        json = BranchSearchInterface.createPayload(requestIn, config, info);
+        Assert.assertFalse(json.has(BranchAutoSuggestRequest.KEY_MAX_RESULTS));
+    }
 }

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchDeviceInfoTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchDeviceInfoTest.java
@@ -1,0 +1,55 @@
+package io.branch.search;
+
+import android.content.Intent;
+import android.os.Build;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * {@link BranchDeviceInfo} class tests.
+ */
+@RunWith(AndroidJUnit4.class)
+public class BranchDeviceInfoTest extends BranchTest {
+
+    @Test
+    public void testDefaults() {
+        BranchDeviceInfo info = new BranchDeviceInfo();
+
+        // Statically initialized fields
+        Assert.assertEquals(Build.MANUFACTURER, info.getBrand());
+        Assert.assertEquals(Build.MODEL, info.getModel());
+        Assert.assertEquals(Build.VERSION.SDK_INT, info.getOSVersion());
+
+        // Before initialization, fields should be null/default
+        Assert.assertEquals(BranchDeviceInfo.DEFAULT_LOCALE, info.getLocale());
+        Assert.assertEquals(BranchDeviceInfo.UNKNOWN_CARRIER, info.getCarrier());
+        Assert.assertNull(info.getAppPackage());
+        Assert.assertNull(info.getAppVersion());
+
+        info.sync(getTestContext());
+
+        // After initialization, fields should be set
+        // Can't test locale/carrier as they depend on the device running the test suite
+        Assert.assertNotNull(info.getAppPackage());
+        Assert.assertNotNull(info.getAppVersion());
+    }
+
+    @Test
+    public void testAddDeviceInfo() {
+        BranchDeviceInfo info = new BranchDeviceInfo();
+        info.sync(getTestContext());
+        info.latitude = 50;
+        info.longitude = 30;
+        JSONObject object = new JSONObject();
+        info.addDeviceInfo(object);
+
+        Assert.assertEquals(50, object.optDouble(BranchDeviceInfo.JSONKey.Latitude.toString()), 0.01);
+        Assert.assertEquals(30, object.optDouble(BranchDeviceInfo.JSONKey.Longitude.toString()), 0.01);
+        Assert.assertTrue(object.has(BranchDeviceInfo.JSONKey.AppPackage.toString()));
+        Assert.assertTrue(object.has(BranchDeviceInfo.JSONKey.AppVersion.toString()));
+    }
+}

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchDiscoveryRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchDiscoveryRequestTest.java
@@ -1,0 +1,99 @@
+package io.branch.search;
+
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+import android.util.Log;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * {@link BranchDiscoveryRequest} tests.
+ */
+public abstract class BranchDiscoveryRequestTest {
+
+    @NonNull
+    protected abstract BranchDiscoveryRequest newRequest();
+
+    @Test
+    public void testTimestamp() {
+        BranchDiscoveryRequest request = newRequest();
+        BranchConfiguration configuration = new BranchConfiguration();
+        BranchDeviceInfo info = new BranchDeviceInfo();
+        JSONObject json = BranchSearchInterface.createPayload(request, configuration, info);
+        Assert.assertTrue(json.has(BranchDiscoveryRequest.KEY_TIMESTAMP));
+    }
+
+    @Test
+    public void testSetExtra() {
+        BranchDiscoveryRequest request = newRequest();
+        BranchConfiguration configuration = new BranchConfiguration();
+        BranchDeviceInfo info = new BranchDeviceInfo();
+        JSONObject json;
+
+        // If no extra is present, json should not even have the extra key.
+        json = BranchSearchInterface.createPayload(request, configuration, info);
+        Assert.assertFalse(json.has(BranchDiscoveryRequest.KEY_EXTRA));
+
+        // If some extra is present, it will be inside a child json object.
+        request.setExtra("theme", "dark");
+        json = BranchSearchInterface.createPayload(request, configuration, info);
+        JSONObject extra = json.optJSONObject(BranchDiscoveryRequest.KEY_EXTRA);
+        Assert.assertNotNull(extra);
+        Assert.assertEquals("dark", extra.optString("theme"));
+
+        // If null is passed, the object is cleared.
+        request.setExtra("theme", null);
+        json = BranchSearchInterface.createPayload(request, configuration, info);
+        Assert.assertFalse(json.has(BranchDiscoveryRequest.KEY_EXTRA));
+    }
+
+    @Test
+    public void testSetExtra_overridesConfiguration() {
+        BranchDeviceInfo info = new BranchDeviceInfo();
+        BranchConfiguration configuration = new BranchConfiguration();
+        configuration.addRequestExtra("theme", "light");
+        configuration.addRequestExtra("size", "small");
+
+        BranchDiscoveryRequest request = newRequest();
+        request.setExtra("theme", "dark");
+        JSONObject json = BranchSearchInterface.createPayload(request, configuration, info);
+        JSONObject extra = json.optJSONObject(BranchDiscoveryRequest.KEY_EXTRA);
+        Assert.assertNotNull(extra);
+
+        // Should override "theme" but leave "size" as is.
+        Assert.assertEquals("dark", extra.optString("theme"));
+        Assert.assertEquals("small", extra.optString("size"));
+    }
+
+    // NOTE: This is not testing the request classes... Move to BranchSearchInterfaceTest?
+    @Test
+    public void testHasDeviceInfo() throws Throwable {
+        BranchDiscoveryRequest request = newRequest();
+        JSONObject jsonOut = BranchSearchInterface.createPayload(request,
+                new BranchConfiguration(), new BranchDeviceInfo());
+
+        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Brand.toString()));
+        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Model.toString()));
+        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.OSVersion.toString()));
+        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Carrier.toString()));
+        Assert.assertEquals("ANDROID", jsonOut.getString(BranchDeviceInfo.JSONKey.OS.toString()));
+    }
+
+    // NOTE: This is not testing the request classes... Move to BranchSearchInterfaceTest?
+    @Test
+    public void testHasConfiguration() throws Throwable {
+        BranchDiscoveryRequest request = newRequest();
+        BranchDeviceInfo info = new BranchDeviceInfo();
+        BranchConfiguration config = new BranchConfiguration();
+        config.setBranchKey("key_live_123"); // need a "valid" key
+        config.setCountryCode("ZZ");
+        config.setGoogleAdID("XYZ");
+        JSONObject json = BranchSearchInterface.createPayload(request, config, info);
+        Assert.assertEquals("key_live_123", json.getString(BranchConfiguration.JSONKey.BranchKey.toString()));
+        Assert.assertEquals("ZZ", json.getString(BranchConfiguration.JSONKey.Country.toString()));
+        Assert.assertEquals("XYZ", json.getString(BranchConfiguration.JSONKey.GAID.toString()));
+        Assert.assertFalse(TextUtils.isEmpty(json.getString(BranchConfiguration.JSONKey.Locale.toString())));
+    }
+}

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchHammerTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchHammerTest.java
@@ -3,19 +3,13 @@ package io.branch.search;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
 import android.support.test.runner.AndroidJUnit4;
-import android.text.TextUtils;
 import android.util.Log;
 
-import junit.framework.Assert;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +21,7 @@ public class BranchHammerTest extends BranchTest {
     private static final String TAG = "Branch::HammerTest";
 
     private static BranchSearchRequest createTestRequest(String query) {
-        BranchSearchRequest request = BranchSearchRequest.Create(query);
+        BranchSearchRequest request = BranchSearchRequest.create(query);
 
         request.setMaxAppResults(100);
         request.setMaxContentPerAppResults(200);

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchHammerTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchHammerTest.java
@@ -20,13 +20,26 @@ import java.util.concurrent.TimeUnit;
 public class BranchHammerTest extends BranchTest {
     private static final String TAG = "Branch::HammerTest";
 
-    private static BranchSearchRequest createTestRequest(String query) {
+    @NonNull
+    private static BranchSearchRequest newSearchRequest(@NonNull String query) {
         BranchSearchRequest request = BranchSearchRequest.create(query);
-
         request.setMaxAppResults(100);
         request.setMaxContentPerAppResults(200);
         request.disableQueryModification();
+        return request;
+    }
 
+    @NonNull
+    private static BranchAutoSuggestRequest newAutoSuggestRequest(@NonNull String query) {
+        BranchAutoSuggestRequest request = BranchAutoSuggestRequest.create(query);
+        request.setExtra("foo", "bar");
+        return request;
+    }
+
+    @NonNull
+    private static BranchQueryHintRequest newQueryHintRequest() {
+        BranchQueryHintRequest request = BranchQueryHintRequest.create();
+        request.setMaxResults(60);
         return request;
     }
 
@@ -42,7 +55,9 @@ public class BranchHammerTest extends BranchTest {
     class DoQuery extends Thread implements IBranchSearchEvents, IBranchQueryResults {
 
         final CountDownLatch mLatch;
-        BranchSearchRequest mRequest;
+        BranchSearchRequest mSearchRequest;
+        BranchAutoSuggestRequest mAutoSuggestRequest;
+        BranchQueryHintRequest mQueryHintRequest;
         long mStart;
         long mEnd;
         final int mId;
@@ -52,16 +67,18 @@ public class BranchHammerTest extends BranchTest {
             setName("HammerThread #" + id);
             mId = id;
             mLatch = latch;
-            mRequest = createTestRequest(query);
+            mSearchRequest = newSearchRequest(query);
+            mAutoSuggestRequest = newAutoSuggestRequest(query);
+            mQueryHintRequest = newQueryHintRequest();
         }
 
         @Override
         public void run() {
             Log.d(TAG, "Query#:" + mId + " STARTED.");
             mStart = System.currentTimeMillis();
-//            BranchSearch.getInstance().query(mRequest, this);
-            BranchSearch.getInstance().queryHint( this);
-//            BranchSearch.getInstance().autoSuggest( mRequest, this);
+//            BranchSearch.getInstance().query(mSearchRequest, this);
+            BranchSearch.getInstance().queryHint( mQueryHintRequest, this);
+//            BranchSearch.getInstance().autoSuggest( mAutoSuggestRequest, this);
         }
 
         boolean didSucceed() {
@@ -113,9 +130,9 @@ public class BranchHammerTest extends BranchTest {
         public void run() {
             Log.d(TAG, "Query#:" + mId + " STARTED.");
             mStart = System.currentTimeMillis();
-            BranchSearch.getInstance().query(mRequest, this);
-            BranchSearch.getInstance().queryHint( this);
-            BranchSearch.getInstance().autoSuggest( mRequest, this);
+            BranchSearch.getInstance().query(mSearchRequest, this);
+            BranchSearch.getInstance().queryHint(mQueryHintRequest,this);
+            BranchSearch.getInstance().autoSuggest(mAutoSuggestRequest, this);
         }
     }
 

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
@@ -16,6 +16,7 @@ public class BranchQueryHintRequestTest {
     @Test
     public void testRequestCreation() throws Throwable {
         BranchQueryHintRequest requestIn = BranchQueryHintRequest.create();
+        requestIn.setMaxResults(12);
 
         BranchConfiguration config = new BranchConfiguration();
         config.setBranchKey("key_live_123"); // need a "valid" key
@@ -24,13 +25,12 @@ public class BranchQueryHintRequestTest {
 
         BranchDeviceInfo info = new BranchDeviceInfo();
         JSONObject jsonIn = BranchSearchInterface.createPayload(requestIn, config, info);
-
         Log.d("Branch", "QueryHint::testRequestCreation(): " + jsonIn.toString());
+        Assert.assertEquals(12, jsonIn.getInt(BranchQueryHintRequest.KEY_MAX_RESULTS));
 
         Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.BranchKey.toString()), "key_live_123");
         Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.Country.toString()), "ZZ");
         Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.GAID.toString()), "XYZ");
-
         Assert.assertEquals(jsonIn.getString(BranchDeviceInfo.JSONKey.OS.toString()), "ANDROID");
     }
 
@@ -45,10 +45,5 @@ public class BranchQueryHintRequestTest {
         Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Model.toString()));
         Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.OSVersion.toString()));
         Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Carrier.toString()));
-    }
-
-    @Test
-    public void testQueryHint() {
-
     }
 }

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
@@ -15,7 +15,7 @@ import org.junit.runner.RunWith;
 public class BranchQueryHintRequestTest {
     @Test
     public void testRequestCreation() throws Throwable {
-        BranchQueryHintRequest requestIn = BranchQueryHintRequest.Create();
+        BranchQueryHintRequest requestIn = BranchQueryHintRequest.create();
 
         BranchConfiguration config = new BranchConfiguration();
         config.setBranchKey("key_live_123"); // need a "valid" key
@@ -36,7 +36,7 @@ public class BranchQueryHintRequestTest {
 
     @Test
     public void testHasDeviceInfo() throws Throwable {
-        BranchQueryHintRequest request = BranchQueryHintRequest.Create();
+        BranchQueryHintRequest request = BranchQueryHintRequest.create();
 
         JSONObject jsonOut = BranchSearchInterface.createPayload(request,
                 new BranchConfiguration(), new BranchDeviceInfo());

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchQueryHintRequestTest.java
@@ -1,5 +1,6 @@
 package io.branch.search;
 
+import android.support.annotation.NonNull;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 
@@ -9,41 +10,29 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * QueryHint Request Tests.
+ * {@link BranchQueryHintRequest} tests.
  */
 @RunWith(AndroidJUnit4.class)
-public class BranchQueryHintRequestTest {
-    @Test
-    public void testRequestCreation() throws Throwable {
-        BranchQueryHintRequest requestIn = BranchQueryHintRequest.create();
-        requestIn.setMaxResults(12);
+public class BranchQueryHintRequestTest extends BranchDiscoveryRequestTest {
 
-        BranchConfiguration config = new BranchConfiguration();
-        config.setBranchKey("key_live_123"); // need a "valid" key
-        config.setCountryCode("ZZ");
-        config.setGoogleAdID("XYZ");
-
-        BranchDeviceInfo info = new BranchDeviceInfo();
-        JSONObject jsonIn = BranchSearchInterface.createPayload(requestIn, config, info);
-        Log.d("Branch", "QueryHint::testRequestCreation(): " + jsonIn.toString());
-        Assert.assertEquals(12, jsonIn.getInt(BranchQueryHintRequest.KEY_MAX_RESULTS));
-
-        Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.BranchKey.toString()), "key_live_123");
-        Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.Country.toString()), "ZZ");
-        Assert.assertEquals(jsonIn.getString(BranchConfiguration.JSONKey.GAID.toString()), "XYZ");
-        Assert.assertEquals(jsonIn.getString(BranchDeviceInfo.JSONKey.OS.toString()), "ANDROID");
+    @NonNull
+    @Override
+    protected BranchDiscoveryRequest newRequest() {
+        return BranchQueryHintRequest.create();
     }
 
     @Test
-    public void testHasDeviceInfo() throws Throwable {
-        BranchQueryHintRequest request = BranchQueryHintRequest.create();
+    public void testMaxResults() throws Throwable {
+        BranchQueryHintRequest requestIn = BranchQueryHintRequest.create();
+        BranchConfiguration config = new BranchConfiguration();
+        BranchDeviceInfo info = new BranchDeviceInfo();
 
-        JSONObject jsonOut = BranchSearchInterface.createPayload(request,
-                new BranchConfiguration(), new BranchDeviceInfo());
+        requestIn.setMaxResults(12);
+        JSONObject json = BranchSearchInterface.createPayload(requestIn, config, info);
+        Assert.assertEquals(12, json.getInt(BranchQueryHintRequest.KEY_MAX_RESULTS));
 
-        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Brand.toString()));
-        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Model.toString()));
-        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.OSVersion.toString()));
-        Assert.assertNotNull(jsonOut.getString(BranchDeviceInfo.JSONKey.Carrier.toString()));
+        requestIn.setMaxResults(-1);
+        json = BranchSearchInterface.createPayload(requestIn, config, info);
+        Assert.assertFalse(json.has(BranchQueryHintRequest.KEY_MAX_RESULTS));
     }
 }

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchInterfaceTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchInterfaceTest.java
@@ -54,7 +54,7 @@ public class BranchSearchInterfaceTest extends BranchTest {
                 Mockito.anyString(),
                 Mockito.any(JSONObject.class),
                 Mockito.any(IURLConnectionEvents.class));
-        BranchSearchRequest request = BranchSearchRequest.Create("food");
+        BranchSearchRequest request = BranchSearchRequest.create("food");
 
         // Perform the request and ensure we have results.
         final CountDownLatch latch = new CountDownLatch(1);
@@ -91,7 +91,7 @@ public class BranchSearchInterfaceTest extends BranchTest {
                 Mockito.anyString(),
                 Mockito.any(JSONObject.class),
                 Mockito.any(IURLConnectionEvents.class));
-        BranchSearchRequest request = BranchSearchRequest.Create("pizza");
+        BranchSearchRequest request = BranchSearchRequest.create("pizza");
 
         // When service enabled is triggered...
         // Case 1: return ENABLED. So the final error should be UNAUTHORIZED_ERR.

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchRequestTest.java
@@ -20,7 +20,7 @@ public class BranchSearchRequestTest {
 
     @Test
     public void testRequestCreation() throws Throwable {
-        BranchSearchRequest requestIn = BranchSearchRequest.Create("餐厅");
+        BranchSearchRequest requestIn = BranchSearchRequest.create("餐厅");
 
         requestIn.setMaxAppResults(100);
         requestIn.setMaxContentPerAppResults(200);
@@ -37,13 +37,12 @@ public class BranchSearchRequestTest {
         JSONObject jsonIn = BranchSearchInterface.createPayload(requestIn, config, info);
         Log.d("Branch", "SearchRequest::testRequestCreation(): " + jsonIn.toString());
 
-        Assert.assertEquals(100,
-                jsonIn.getInt(BranchSearchRequest.JSONKey.LimitAppResults.toString()));
-        Assert.assertEquals(200,
-                jsonIn.getInt(BranchSearchRequest.JSONKey.LimitLinkResults.toString()));
-        Assert.assertTrue(jsonIn.getBoolean(BranchSearchRequest.JSONKey.DoNotModify.toString()));
+        Assert.assertEquals("餐厅", jsonIn.getString(BranchSearchRequest.KEY_USER_QUERY));
+        Assert.assertEquals(100, jsonIn.getInt(BranchSearchRequest.KEY_LIMIT_APP_RESULTS));
+        Assert.assertEquals(200, jsonIn.getInt(BranchSearchRequest.KEY_LIMIT_LINK_RESULTS));
+        Assert.assertTrue(jsonIn.getBoolean(BranchSearchRequest.KEY_DO_NOT_MODIFY));
         Assert.assertEquals(BranchQuerySource.QUERY_HINT_RESULTS.toString(),
-                jsonIn.getString(BranchSearchRequest.JSONKey.QuerySource.toString()));
+                jsonIn.getString(BranchSearchRequest.KEY_QUERY_SOURCE));
 
         Assert.assertEquals("key_live_123", jsonIn.getString(BranchConfiguration.JSONKey.BranchKey.toString()));
         Assert.assertEquals("ZZ", jsonIn.getString(BranchConfiguration.JSONKey.Country.toString()));
@@ -55,7 +54,7 @@ public class BranchSearchRequestTest {
 
     @Test
     public void testHasDeviceInfo() throws Throwable {
-        BranchSearchRequest request = BranchSearchRequest.Create("MOD Pizza");
+        BranchSearchRequest request = BranchSearchRequest.create("MOD Pizza");
         JSONObject jsonOut = BranchSearchInterface.createPayload(request,
                 new BranchConfiguration(), new BranchDeviceInfo());
 
@@ -69,7 +68,7 @@ public class BranchSearchRequestTest {
     public void testHasQueryModificationFlag() throws Throwable {
         final String MODIFY_KEY = "do_not_modify";
 
-        BranchSearchRequest request = BranchSearchRequest.Create("MOD Pizza");
+        BranchSearchRequest request = BranchSearchRequest.create("MOD Pizza");
         JSONObject jsonOut = BranchSearchInterface.createPayload(request,
                 new BranchConfiguration(), new BranchDeviceInfo());
 
@@ -92,7 +91,7 @@ public class BranchSearchRequestTest {
 
     @Test
     public void testSetExtra() {
-        BranchSearchRequest request = BranchSearchRequest.Create("Pizza");
+        BranchSearchRequest request = BranchSearchRequest.create("Pizza");
         BranchConfiguration configuration = new BranchConfiguration();
         BranchDeviceInfo info = new BranchDeviceInfo();
         JSONObject json;
@@ -121,7 +120,7 @@ public class BranchSearchRequestTest {
         configuration.addRequestExtra("theme", "light");
         configuration.addRequestExtra("size", "small");
 
-        BranchSearchRequest request = BranchSearchRequest.Create("Pizza");
+        BranchSearchRequest request = BranchSearchRequest.create("Pizza");
         request.setExtra("theme", "dark");
         JSONObject json = BranchSearchInterface.createPayload(request, configuration, info);
         JSONObject extra = json.optJSONObject(BranchDiscoveryRequest.JSONKey.Extra.toString());
@@ -136,7 +135,7 @@ public class BranchSearchRequestTest {
     public void testOverrideLocale() {
         String testLocale = "xx_YY";
 
-        BranchSearchRequest request = BranchSearchRequest.Create("MOD Pizza");
+        BranchSearchRequest request = BranchSearchRequest.create("MOD Pizza");
         BranchConfiguration config = new BranchConfiguration();
         BranchDeviceInfo info = new BranchDeviceInfo();
 

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchResultTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchResultTest.java
@@ -1,11 +1,8 @@
 package io.branch.search;
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import org.json.JSONObject;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +31,7 @@ public class BranchSearchResultTest extends BranchTest {
 
         JSONObject jsonResponse = new JSONObject(response);
 
-        BranchSearchRequest request = BranchSearchRequest.Create("Mexican");
+        BranchSearchRequest request = BranchSearchRequest.create("Mexican");
         BranchSearchResult result = BranchResponseParser.parse(request, jsonResponse);
         Assert.assertNotNull(result);
 
@@ -54,7 +51,7 @@ public class BranchSearchResultTest extends BranchTest {
 
         JSONObject jsonResponse = new JSONObject(response);
 
-        BranchSearchRequest request = BranchSearchRequest.Create("Mexican");
+        BranchSearchRequest request = BranchSearchRequest.create("Mexican");
         BranchSearchResult result = BranchResponseParser.parse(request, jsonResponse);
         Assert.assertNotNull(result);
 
@@ -70,7 +67,7 @@ public class BranchSearchResultTest extends BranchTest {
 
         JSONObject jsonResponse = new JSONObject(response);
 
-        BranchSearchRequest request = BranchSearchRequest.Create("Mexican");
+        BranchSearchRequest request = BranchSearchRequest.create("Mexican");
         BranchSearchResult result = BranchResponseParser.parse(request, jsonResponse);
         Assert.assertNotNull(result);
 
@@ -83,7 +80,7 @@ public class BranchSearchResultTest extends BranchTest {
     @Test
     public void testResultSuccess_empty3() {
         // Parse with an empty JSONObject
-        BranchSearchRequest request = BranchSearchRequest.Create("Mexican");
+        BranchSearchRequest request = BranchSearchRequest.create("Mexican");
         BranchSearchResult result = BranchResponseParser.parse(request, new JSONObject());
         Assert.assertNotNull(result);
     }
@@ -95,7 +92,7 @@ public class BranchSearchResultTest extends BranchTest {
 
         JSONObject jsonResponse = new JSONObject(response);
 
-        BranchSearchRequest request = BranchSearchRequest.Create("Mexican");
+        BranchSearchRequest request = BranchSearchRequest.create("Mexican");
         BranchSearchResult result = BranchResponseParser.parse(request, jsonResponse);
         Assert.assertNotNull(result);
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchAutoSuggestRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchAutoSuggestRequest.java
@@ -11,7 +11,9 @@ import org.json.JSONObject;
 public class BranchAutoSuggestRequest extends BranchDiscoveryRequest<BranchAutoSuggestRequest> {
 
     static final String KEY_USER_QUERY = "user_query";
+    static final String KEY_MAX_RESULTS = "num";
 
+    private int maxResults = 0;
     @NonNull
     private final String query;
 
@@ -28,6 +30,17 @@ public class BranchAutoSuggestRequest extends BranchDiscoveryRequest<BranchAutoS
         this.query = query;
     }
 
+    /**
+     * Sets the maximum number of hints that the query should return.
+     * @param maxResults max results
+     * @return this for chaining
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    public BranchAutoSuggestRequest setMaxResults(int maxResults) {
+        this.maxResults = maxResults;
+        return this;
+    }
+
     @NonNull
     public String getQuery() {
         return query;
@@ -39,6 +52,9 @@ public class BranchAutoSuggestRequest extends BranchDiscoveryRequest<BranchAutoS
         JSONObject object = super.toJson();
         try {
             object.putOpt(KEY_USER_QUERY, query);
+            if (maxResults > 0) {
+                object.putOpt(KEY_MAX_RESULTS, maxResults);
+            }
         } catch (JSONException ignore) {}
         return object;
     }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchAutoSuggestRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchAutoSuggestRequest.java
@@ -1,0 +1,45 @@
+package io.branch.search;
+
+import android.support.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+ * Request model for auto suggest requests.
+ */
+public class BranchAutoSuggestRequest extends BranchDiscoveryRequest<BranchAutoSuggestRequest> {
+
+    static final String KEY_USER_QUERY = "user_query";
+
+    @NonNull
+    private final String query;
+
+    /**
+     * Factory Method to create a new BranchAutoSuggestRequest.
+     * @return a new BranchAutoSuggestRequest.
+     */
+    @NonNull
+    public static BranchAutoSuggestRequest create(@NonNull String query) {
+        return new BranchAutoSuggestRequest(query);
+    }
+
+    private BranchAutoSuggestRequest(@NonNull String query) {
+        this.query = query;
+    }
+
+    @NonNull
+    public String getQuery() {
+        return query;
+    }
+
+    @NonNull
+    @Override
+    JSONObject toJson() {
+        JSONObject object = super.toJson();
+        try {
+            object.putOpt(KEY_USER_QUERY, query);
+        } catch (JSONException ignore) {}
+        return object;
+    }
+}

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchAutoSuggestRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchAutoSuggestRequest.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
 public class BranchAutoSuggestRequest extends BranchDiscoveryRequest<BranchAutoSuggestRequest> {
 
     static final String KEY_USER_QUERY = "user_query";
-    static final String KEY_MAX_RESULTS = "num";
+    static final String KEY_MAX_RESULTS = "limit";
 
     private int maxResults = 0;
     @NonNull

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
@@ -49,7 +49,7 @@ public class BranchConfiguration {
         Country("country"),
         GAID("gaid"),
         LAT("is_lat"),
-        /** matches {@link BranchDiscoveryRequest.JSONKey#Extra} */
+        /** matched by {@link BranchDiscoveryRequest#KEY_EXTRA} */
         RequestExtra("extra_data"),
         /** overrides {@link BranchDeviceInfo.JSONKey#Locale} */
         Locale(BranchDeviceInfo.JSONKey.Locale.toString());

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -104,12 +104,10 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
             object.putOpt(KEY_TIMESTAMP, System.currentTimeMillis());
 
             // Add extra data.
-            // The JSONObject for this key might already exist because the key is shared
-            // between this class and BranchConfiguration.
+            // The JSONObject for this key is shared between this class and BranchConfiguration.
+            // But our extra data has priority so BranchConfiguration will never overwrite these values.
             if (!extra.keySet().isEmpty()) {
-                JSONObject extraData = object.optJSONObject(KEY_EXTRA);
-                if (extraData == null) extraData = new JSONObject();
-
+                JSONObject extraData = new JSONObject();
                 for (String key : extra.keySet()) {
                     Object value = extra.get(key);
                     extraData.putOpt(key, value);

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -16,23 +16,9 @@ import java.util.Map;
 @SuppressWarnings("unchecked")
 public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
 
-    enum JSONKey {
-        Timestamp("utc_timestamp"),
-        /** we want to override the configuration-level extras */
-        Extra(BranchConfiguration.JSONKey.RequestExtra.toString());
-
-        JSONKey(String key) {
-            _key = key;
-        }
-
-        @NonNull
-        @Override
-        public String toString() {
-            return _key;
-        }
-
-        private String _key;
-    }
+    final static String KEY_TIMESTAMP = "utc_timestamp";
+    // We want to override the configuration-level extras
+    final static String KEY_EXTRA = BranchConfiguration.JSONKey.RequestExtra.toString();
 
     private final Map<String, Object> extra = new HashMap<>();
 
@@ -100,6 +86,7 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
      * @return this BranchDiscoveryRequest
      */
     @SuppressWarnings("WeakerAccess")
+    @NonNull
     public T setExtra(@NonNull String key, @Nullable Object data) {
         if (data == null) {
             extra.remove(key);
@@ -109,27 +96,27 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
         return (T) this;
     }
 
-    void toJson(@NonNull JSONObject jsonObject) {
+    @NonNull
+    JSONObject toJson() {
+        JSONObject object = new JSONObject();
         try {
             // Add the current timestamp.
-            Long tsLong = System.currentTimeMillis();
-            jsonObject.putOpt(JSONKey.Timestamp.toString(), tsLong);
+            object.putOpt(KEY_TIMESTAMP, System.currentTimeMillis());
 
             // Add extra data.
             // The JSONObject for this key might already exist because the key is shared
             // between this class and BranchConfiguration.
             if (!extra.keySet().isEmpty()) {
-                JSONObject extraData = jsonObject.optJSONObject(JSONKey.Extra.toString());
+                JSONObject extraData = object.optJSONObject(KEY_EXTRA);
                 if (extraData == null) extraData = new JSONObject();
 
                 for (String key : extra.keySet()) {
                     Object value = extra.get(key);
                     extraData.putOpt(key, value);
                 }
-                jsonObject.putOpt(JSONKey.Extra.toString(), extraData);
+                object.putOpt(KEY_EXTRA, extraData);
             }
-
-
         } catch (JSONException ignore) { }
+        return object;
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchDiscoveryRequest.java
@@ -109,7 +109,7 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
         return (T) this;
     }
 
-    JSONObject convertToJson(JSONObject jsonObject) {
+    void toJson(@NonNull JSONObject jsonObject) {
         try {
             // Add the current timestamp.
             Long tsLong = System.currentTimeMillis();
@@ -130,8 +130,6 @@ public class BranchDiscoveryRequest<T extends BranchDiscoveryRequest> {
             }
 
 
-        } catch (JSONException ignore) {
-        }
-        return jsonObject;
+        } catch (JSONException ignore) { }
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
@@ -1,24 +1,27 @@
 package io.branch.search;
 
+import android.support.annotation.NonNull;
+
 import org.json.JSONObject;
 
 /**
- * Request model for Branch Search.
+ * Request model for query hint requests.
  */
-class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHintRequest> {
+public class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHintRequest> {
 
     /**
      * Factory Method to create a new BranchQueryHintRequest.
      * @return a new BranchQueryHintRequest.
      */
-    static BranchQueryHintRequest Create() {
-        return new  BranchQueryHintRequest();
+    @NonNull
+    public static BranchQueryHintRequest create() {
+        return new BranchQueryHintRequest();
     }
 
-    JSONObject convertToJson() {
+    @NonNull
+    JSONObject toJson() {
         JSONObject object = new JSONObject();
-        super.convertToJson(object);
-
+        super.toJson(object);
         return object;
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
@@ -2,12 +2,17 @@ package io.branch.search;
 
 import android.support.annotation.NonNull;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
  * Request model for query hint requests.
  */
 public class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHintRequest> {
+
+    static final String KEY_MAX_RESULTS = "max_results";
+
+    private int maxResults = 0;
 
     /**
      * Factory Method to create a new BranchQueryHintRequest.
@@ -18,10 +23,26 @@ public class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHi
         return new BranchQueryHintRequest();
     }
 
+    /**
+     * Sets the maximum number of hints that the query should return.
+     * @param maxResults max results
+     * @return this for chaining
+     */
+    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
+    public BranchQueryHintRequest setMaxResults(int maxResults) {
+        this.maxResults = maxResults;
+        return this;
+    }
+
     @NonNull
     JSONObject toJson() {
         JSONObject object = new JSONObject();
         super.toJson(object);
+        try {
+            if (maxResults > 0) {
+                object.putOpt(KEY_MAX_RESULTS, maxResults);
+            }
+        } catch (JSONException ignore) {}
         return object;
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
@@ -23,6 +23,8 @@ public class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHi
         return new BranchQueryHintRequest();
     }
 
+    private BranchQueryHintRequest() {}
+
     /**
      * Sets the maximum number of hints that the query should return.
      * @param maxResults max results

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
@@ -35,9 +35,9 @@ public class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHi
     }
 
     @NonNull
+    @Override
     JSONObject toJson() {
-        JSONObject object = new JSONObject();
-        super.toJson(object);
+        JSONObject object = super.toJson();
         try {
             if (maxResults > 0) {
                 object.putOpt(KEY_MAX_RESULTS, maxResults);

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchQueryHintRequest.java
@@ -10,7 +10,7 @@ import org.json.JSONObject;
  */
 public class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHintRequest> {
 
-    static final String KEY_MAX_RESULTS = "max_results";
+    static final String KEY_MAX_RESULTS = "num";
 
     private int maxResults = 0;
 
@@ -30,7 +30,7 @@ public class BranchQueryHintRequest extends BranchDiscoveryRequest<BranchQueryHi
      * @param maxResults max results
      * @return this for chaining
      */
-    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
+    @SuppressWarnings("UnusedReturnValue")
     public BranchQueryHintRequest setMaxResults(int maxResults) {
         this.maxResults = maxResults;
         return this;

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
@@ -98,29 +98,33 @@ public class BranchSearch {
      * @param callback {@link IBranchSearchEvents} Callback to receive results
      * @return true if the request was posted
      */
-    public boolean query(BranchSearchRequest request, IBranchSearchEvents callback) {
+    public boolean query(@NonNull BranchSearchRequest request,
+                         @NonNull IBranchSearchEvents callback) {
         return BranchSearchInterface.search(request, callback);
     }
 
     /**
      * Retrieve a list of suggestions on kinds of things one might request.
+     * @param request A request object
      * @param callback {@link IBranchQueryResults} Callback to receive results.
      * @return true if the request was posted.
      */
     @SuppressWarnings("UnusedReturnValue")
-    public boolean queryHint(final IBranchQueryResults callback) {
-        return BranchSearchInterface.queryHint(new BranchQueryHintRequest(), callback);
+    public boolean queryHint(@NonNull BranchQueryHintRequest request,
+                             @NonNull IBranchQueryResults callback) {
+        return BranchSearchInterface.queryHint(request, callback);
     }
 
     /**
      * Retrieve a list of auto-suggestions based on a query parameter.
      * Example:  "piz" might return ["pizza", "pizza near me", "pizza my heart"]
-     * @param request {@link BranchSearchRequest} request
+     * @param request {@link BranchAutoSuggestRequest} request
      * @param callback {@link IBranchQueryResults} Callback to receive results.
      * @return true if the request was posted.
      */
     @SuppressWarnings("UnusedReturnValue")
-    public boolean autoSuggest(BranchSearchRequest request, final IBranchQueryResults callback) {
+    public boolean autoSuggest(@NonNull BranchAutoSuggestRequest request,
+                               @NonNull IBranchQueryResults callback) {
         return BranchSearchInterface.autoSuggest(request, callback);
     }
 
@@ -183,7 +187,7 @@ public class BranchSearch {
     @SuppressWarnings("WeakerAccess")
     public static void isServiceEnabled(@NonNull String branchKey,
                                         @NonNull IBranchServiceEnabledEvents callback) {
-        BranchSearchInterface.ServiceEnabled(branchKey, callback);
+        BranchSearchInterface.serviceEnabled(branchKey, callback);
     }
 
     @NonNull

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
@@ -125,7 +125,8 @@ public class BranchSearch {
     }
 
     // Package Private
-    URLConnectionNetworkHandler getNetworkHandler(Channel channel) {
+    @NonNull
+    URLConnectionNetworkHandler getNetworkHandler(@NonNull Channel channel) {
         return this.networkHandlers[channel.ordinal()];
     }
 
@@ -133,6 +134,8 @@ public class BranchSearch {
     // TODO This should not be public! Once the user creates a configuration and initializes
     //  the SDK, he should not be able to change the configuration values while we're running, or
     //  our behavior might change/break/be undefined.
+    @SuppressWarnings("WeakerAccess")
+    @NonNull
     public final BranchConfiguration getBranchConfiguration() {
         return branchConfiguration;
     }
@@ -177,6 +180,7 @@ public class BranchSearch {
      * @param branchKey the branch key to check
      * @param callback a callback for receiving results
      */
+    @SuppressWarnings("WeakerAccess")
     public static void isServiceEnabled(@NonNull String branchKey,
                                         @NonNull IBranchServiceEnabledEvents callback) {
         BranchSearchInterface.ServiceEnabled(branchKey, callback);

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearch.java
@@ -205,4 +205,31 @@ public class BranchSearch {
         branchDeviceInfo.latitude = latitude;
         branchDeviceInfo.longitude = longitude;
     }
+
+    // Legacy
+    // Deprecated version of our APIs
+
+    /**
+     * Legacy: retrieve a list of suggestions on kinds of things one might request.
+     * @deprecated please use {@link #queryHint(BranchQueryHintRequest, IBranchQueryResults)} instead
+     * @return true if the request was posted.
+     */
+    @Deprecated
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean queryHint(@NonNull IBranchQueryResults callback) {
+        return queryHint(BranchQueryHintRequest.create(), callback);
+    }
+
+    /**
+     * Legacy: retrieve a list of auto-suggestions based on a query parameter.
+     * @deprecated please use {@link #autoSuggest(BranchAutoSuggestRequest, IBranchQueryResults)} instead
+     * @return true if the request was posted.
+     */
+    @Deprecated
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean autoSuggest(@NonNull BranchSearchRequest request,
+                               @NonNull IBranchQueryResults callback) {
+        return BranchSearchInterface.autoSuggest(
+                BranchAutoSuggestRequest.create(request.getQuery()), callback);
+    }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchInterface.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchInterface.java
@@ -140,7 +140,7 @@ class BranchSearchInterface {
     static JSONObject createPayload(@NonNull BranchSearchRequest request,
                                     @NonNull BranchConfiguration configuration,
                                     @NonNull BranchDeviceInfo info) {
-        JSONObject jsonPayload = request.convertToJson();
+        JSONObject jsonPayload = request.toJson();
         info.addDeviceInfo(jsonPayload);
         configuration.addConfigurationInfo(jsonPayload);
 
@@ -151,7 +151,7 @@ class BranchSearchInterface {
     static JSONObject createPayload(@NonNull BranchQueryHintRequest request,
                                     @NonNull BranchConfiguration configuration,
                                     @NonNull BranchDeviceInfo info) {
-        JSONObject jsonPayload = request.convertToJson();
+        JSONObject jsonPayload = request.toJson();
         info.addDeviceInfo(jsonPayload);
         configuration.addConfigurationInfo(jsonPayload);
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchInterface.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchInterface.java
@@ -37,7 +37,7 @@ class BranchSearchInterface {
                             == BranchSearchError.ERR_CODE.UNAUTHORIZED_ERR) {
                         // Check if the service is enabled. If it is, we'll return the original
                         // UNAUTHORIZED_ERR error. If it's not, we'll return SERVICE_DISABLED_ERR.
-                        ServiceEnabled(configuration.getBranchKey(), new IBranchServiceEnabledEvents() {
+                        serviceEnabled(configuration.getBranchKey(), new IBranchServiceEnabledEvents() {
                             @Override
                             public void onBranchServiceEnabledResult(@NonNull BranchServiceEnabledResult result) {
                                 if (result.isEnabled()) {
@@ -61,7 +61,7 @@ class BranchSearchInterface {
         return true;
     }
 
-    static boolean autoSuggest(final BranchSearchRequest request,
+    static boolean autoSuggest(final BranchAutoSuggestRequest request,
                                final IBranchQueryResults callback) {
         BranchSearch search = BranchSearch.getInstance();
         if (search == null) {
@@ -116,7 +116,7 @@ class BranchSearchInterface {
         return true;
     }
 
-    static void ServiceEnabled(@NonNull String branchKey,
+    static void serviceEnabled(@NonNull String branchKey,
                                final @NonNull IBranchServiceEnabledEvents callback) {
         // This can be called before initialization, so don't try to get the BranchSearch instance.
         // Also, we don't have a dedicated network channel, so use the raw handler.

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchInterface.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchInterface.java
@@ -137,24 +137,12 @@ class BranchSearchInterface {
     }
 
     @NonNull
-    static JSONObject createPayload(@NonNull BranchSearchRequest request,
+    static JSONObject createPayload(@NonNull BranchDiscoveryRequest request,
                                     @NonNull BranchConfiguration configuration,
                                     @NonNull BranchDeviceInfo info) {
         JSONObject jsonPayload = request.toJson();
         info.addDeviceInfo(jsonPayload);
         configuration.addConfigurationInfo(jsonPayload);
-
-        return jsonPayload;
-    }
-
-    @NonNull
-    static JSONObject createPayload(@NonNull BranchQueryHintRequest request,
-                                    @NonNull BranchConfiguration configuration,
-                                    @NonNull BranchDeviceInfo info) {
-        JSONObject jsonPayload = request.toJson();
-        info.addDeviceInfo(jsonPayload);
-        configuration.addConfigurationInfo(jsonPayload);
-
         return jsonPayload;
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
@@ -34,6 +34,17 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
     private int maxContentPerAppResults = MAX_CONTENT_PER_APP_RESULT;
 
     /**
+     * Deprecated method. Please use {@link #create(String)} instead.
+     * @deprecated please use {@link #create(String)} instead
+     * @return a new BranchSearchRequest.
+     */
+    @Deprecated
+    @NonNull
+    public static BranchSearchRequest Create(@NonNull String query) {
+        return create(query);
+    }
+
+    /**
      * Factory Method to create a new BranchSearchRequest.
      * @param query Query String to use
      * @return a new BranchSearchRequest.

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
@@ -89,9 +89,14 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
     }
 
     @NonNull
+    public String getQuery() {
+        return query;
+    }
+
+    @NonNull
+    @Override
     JSONObject toJson() {
-        JSONObject object = new JSONObject();
-        super.toJson(object);
+        JSONObject object = super.toJson();
         try {
             object.putOpt(KEY_LIMIT_APP_RESULTS, maxAppResults);
             object.putOpt(KEY_LIMIT_LINK_RESULTS, maxContentPerAppResults);
@@ -102,10 +107,5 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
             object.putOpt(KEY_QUERY_SOURCE, querySource);
         } catch (JSONException ignore) {}
         return object;
-    }
-
-    @NonNull
-    public String getQuery() {
-        return query;
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
@@ -1,7 +1,6 @@
 package io.branch.search;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,8 +13,15 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
     private static final int MAX_APP_RESULT = 5;
     private static final int MAX_CONTENT_PER_APP_RESULT = 5;
 
+    static final String KEY_LIMIT_APP_RESULTS = "limit_app_results";
+    static final String KEY_LIMIT_LINK_RESULTS = "limit_link_results";
+    static final String KEY_USER_QUERY = "user_query";
+    static final String KEY_DO_NOT_MODIFY = "do_not_modify";
+    static final String KEY_QUERY_SOURCE = "query_source";
+
     // User query string
-    private final String user_query;
+    @NonNull
+    private final String query;
 
     // Flag to send to the server to indicate the query is exactly what they want.
     private boolean doNotModifyQuery;
@@ -24,44 +30,22 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
     private BranchQuerySource querySource = BranchQuerySource.UNSPECIFIED;
 
     // Result limit params
-    private int maxAppResults;
-
-    private int maxContentPerAppResults;
-
-    enum JSONKey {
-        LimitAppResults("limit_app_results"),
-        LimitLinkResults("limit_link_results"),
-        UserQuery("user_query"),
-        DoNotModify("do_not_modify"),
-        QuerySource("query_source");
-
-        JSONKey(String key) {
-            _key = key;
-        }
-
-        @Override
-        public String toString() {
-            return _key;
-        }
-
-        private String _key;
-    }
+    private int maxAppResults = MAX_APP_RESULT;
+    private int maxContentPerAppResults = MAX_CONTENT_PER_APP_RESULT;
 
     /**
      * Factory Method to create a new BranchSearchRequest.
      * @param query Query String to use
      * @return a new BranchSearchRequest.
      */
-    public static BranchSearchRequest Create(String query) {
+    @NonNull
+    public static BranchSearchRequest create(@NonNull String query) {
         return new BranchSearchRequest(query);
     }
 
-    private BranchSearchRequest(String query) {
+    private BranchSearchRequest(@NonNull String query) {
         super();
-
-        this.user_query = query;
-        maxAppResults = MAX_APP_RESULT;
-        maxContentPerAppResults = MAX_CONTENT_PER_APP_RESULT;
+        this.query = query;
     }
 
     /**
@@ -70,16 +54,22 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
      * the user intended a query other than what they actually typed. For example, because of a typo.
      * @return this BranchSearchRequest
      */
+    @NonNull
+    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
     public BranchSearchRequest disableQueryModification() {
         this.doNotModifyQuery = true;
         return this;
     }
 
+    @NonNull
+    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
     public BranchSearchRequest setMaxContentPerAppResults(int maxContentPerAppResults) {
         this.maxContentPerAppResults = maxContentPerAppResults;
         return this;
     }
 
+    @NonNull
+    @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"})
     public BranchSearchRequest setMaxAppResults(int maxAppResults) {
         this.maxAppResults = maxAppResults;
         return this;
@@ -98,26 +88,25 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
         return this;
     }
 
-    JSONObject convertToJson() {
+    @NonNull
+    JSONObject toJson() {
         JSONObject object = new JSONObject();
-        super.convertToJson(object);
-
+        super.toJson(object);
         try {
-            object.putOpt(JSONKey.LimitAppResults.toString(), maxAppResults);
-            object.putOpt(JSONKey.LimitLinkResults.toString(), maxContentPerAppResults);
-            object.putOpt(JSONKey.UserQuery.toString(), user_query);
-
+            object.putOpt(KEY_LIMIT_APP_RESULTS, maxAppResults);
+            object.putOpt(KEY_LIMIT_LINK_RESULTS, maxContentPerAppResults);
+            object.putOpt(KEY_USER_QUERY, query);
             if (doNotModifyQuery) {
-                object.putOpt(JSONKey.DoNotModify.toString(), true);
+                object.putOpt(KEY_DO_NOT_MODIFY, true);
             }
-
-            object.putOpt(JSONKey.QuerySource.toString(), querySource);
+            object.putOpt(KEY_QUERY_SOURCE, querySource);
         } catch (JSONException ignore) {
         }
         return object;
     }
 
+    @NonNull
     public String getQuery() {
-        return user_query;
+        return query;
     }
 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchSearchRequest.java
@@ -100,8 +100,7 @@ public class BranchSearchRequest extends BranchDiscoveryRequest<BranchSearchRequ
                 object.putOpt(KEY_DO_NOT_MODIFY, true);
             }
             object.putOpt(KEY_QUERY_SOURCE, querySource);
-        } catch (JSONException ignore) {
-        }
+        } catch (JSONException ignore) {}
         return object;
     }
 

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchShortcutHandler.java
@@ -54,6 +54,7 @@ public interface IBranchShortcutHandler {
                         | LauncherApps.ShortcutQuery.FLAG_MATCH_MANIFEST
                         | LauncherApps.ShortcutQuery.FLAG_MATCH_PINNED);
                 query.setPackage(packageName);
+                //noinspection ConstantConditions
                 List<ShortcutInfo> shortcuts = launcherApps.getShortcuts(query, Process.myUserHandle());
                 if (shortcuts != null) {
                     for (ShortcutInfo shortcut : shortcuts) {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The Branch Discovery SDK needs to be initialized before using any search functio
 To educate your users on the value of in-app search, this endpoint will return you a short list of query "hints" that you can suggest to the user to try, even before they've began to type a search query. These are trending queries from a range of content verticals. 
 
 ```java
-        BranchSearch.getInstance().queryHint(new IBranchQueryResults() {
+        BranchQueryHintRequest request = BranchQueryHintRequest.create();
+        BranchSearch.getInstance().queryHint(request, new IBranchQueryResults() {
 
             @Override
             public void onQueryResult(final BranchQueryResult result) {
@@ -110,6 +111,7 @@ To educate your users on the value of in-app search, this endpoint will return y
 As a user is typing, Auto Suggest (sometimes referred to as autocomplete) will return a list of query completions that reflet our best predictions for what the user is searching for. We strongly recommend you add Auto Suggest to your UI since it is a critical element of a modern search experience that users now expect.
 
 ```java
+    BranchAutoSuggestRequest request = BranchAutoSuggestRequest.create("pizza");
     BranchSearch.getInstance().autoSuggest(request, new IBranchQueryResults() {
                 @Override
                 public void onQueryResult(final BranchQueryResult result) {
@@ -144,7 +146,7 @@ we have provided example code that fetches the device's last known location.
 ```java
     // Create a Branch Search Request for the keyword
     // Implementation Note:  Set the last known location before searching.
-    BranchSearchRequest request = BranchSearchRequest.Create(keyword);
+    BranchSearchRequest request = BranchSearchRequest.create(keyword);
 
     // Search for the keyword with the Branch Search SDK
     BranchSearch.getInstance().query(request, new IBranchSearchEvents() {
@@ -170,9 +172,8 @@ we have provided example code that fetches the device's last known location.
 You can control the maximum number of distinct app groups (see format of results in next section) that are returned by the API using the following code. The default is 5.
 
 ```java
-    new BranchSearchRequest(search_phrase)
+    BranchSearchRequest.create(search_phrase)
       .setMaxAppResults(10)
-      .search(context, new IBranchSearchEvents() { ... });
 ```
 
 #### Maximum content per app
@@ -180,9 +181,8 @@ You can control the maximum number of distinct app groups (see format of results
 You can control the maximum number of content links that are returned per app (see format of results in next section) that are returned by the API using the following code. The default is 5.
 
 ```java
-    new BranchSearchRequest(search_phrase)
+    BranchSearchRequest.create(search_phrase)
       .setMaxContentPerAppResults(10)
-      .search(context, new IBranchSearchEvents() { ... });
 ```
 
 ## Displaying the search results from `BranchSearchRequest`


### PR DESCRIPTION
<strike>Contains **breaking changes**</strike> to refactor the SDK inputs (the "request" objects) and address INT-79. This will be followed soon by another breaking PR where we refactor SDK outputs (the result objects).

### Before this PR

Request objects across the 3 APIs are confused. 
- `BranchDiscoveryRequest` is a base class with no real purpose
- `BranchSearchRequest` is used for **both** Search and AutoSuggest, which is confusing because it has many methods specific to Search only (setMaxAppResults()) which do not make sense for AutoSuggest
- `BranchQueryHintRequest` exists but is not public and it is only created internally. This is a problem because the user does not have any option to use the request methods to configure it.

### After this PR

We will have one object per API:
- `BranchSearchRequest` is used for Search API
- `BranchAutoSuggestRequest` is used for AutoSuggest API
- `BranchQueryHintRequest` is used for QueryHint API

All objects inherit from base class `BranchDiscoveryRequest` which holds the common functionality. This is reflected in tests where all request tests inherit from the `BranchDiscoveryRequestTest` class. 

API-specific methods are added to the requests object, for example query hints now have the option to specify the max number of results (INT-79).

### Breaking changes

<strike>The signatures of BranchSearch.queryHint() and BranchSearch.autoSuggest() have been changed to accept the new objects. Also the method Create() in BranchSearchRequest has been fixed to lower case create() (since we have to do a breaking release, better to fix these details as well...)</strike>

Edit: changed it so that it contains no breaking changes, but still there are 3 methods deprecations, that should be listed in the release notes:
- `BranchSearch.queryHint(IBranchQueryResults)`: deprecated in favor of the new `BranchSearch.queryHint(BranchQueryHintRequest, IBranchQueryResults)`.
- `BranchSearch.autoSuggest(BranchSearchRequest, IBranchQueryResults)`: deprecated in favor of the new `BranchSearch.autoSuggest(BranchAutoSuggestRequest, IBranchQueryResults)`
- `BranchSearchRequest.Create(String)`: deprecated in favor of the new `BranchSearchRequest.create(String)` which respects Java conventions.