### PR TITLE
Link handling v2

### DIFF
--- a/BranchSearchDemo/src/main/java/io/branch/search/demo/util/ContentItem.java
+++ b/BranchSearchDemo/src/main/java/io/branch/search/demo/util/ContentItem.java
@@ -171,11 +171,11 @@ public class ContentItem extends LinearLayout implements View.OnClickListener, V
         Object result = v.getTag();
         if (result instanceof BranchLinkResult) {
             BranchLinkResult linkResult = (BranchLinkResult)result;
-            linkResult.openContent(getContext(), true);
+            linkResult.open(getContext());
         } else {
             // Load app header
             BranchAppResult appResult = (BranchAppResult)result;
-            appResult.openSearchDeepLink(getContext(), true);
+            appResult.openApp(getContext(), true);
         }
     }
 

--- a/BranchSearchSDK/build.gradle
+++ b/BranchSearchSDK/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'org.mockito:mockito-android:2.28.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-intents:3.0.2'
 }
 
 

--- a/BranchSearchSDK/src/androidTest/assets/handler_custom_intent.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_custom_intent.json
@@ -1,0 +1,8 @@
+{
+  "@type": "intent",
+  "action": "android.settings.SETTINGS",
+  "extras": {
+    "foo1": "bar1",
+    "foo2": "bar2"
+  }
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_custom_intent_malformed.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_custom_intent_malformed.json
@@ -1,0 +1,4 @@
+{
+  "@type": "intent",
+  "no_action": "No Action! This is malformed"
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_deep_view_1.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_deep_view_1.json
@@ -1,0 +1,7 @@
+{
+  "@type": "deep_view",
+  "links": [{
+    "@type": "view_intent",
+    "data": "https://play.google.com/store/apps/details?id=com.facebook.katana"
+  }]
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_deep_view_2.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_deep_view_2.json
@@ -1,0 +1,11 @@
+{
+  "@type": "deep_view",
+  "links": [{
+    "@type": "test_installed",
+    "package": "not.installed.package",
+    "links": [{
+      "@type": "view_intent",
+      "data": "https://google.com"
+    }]
+  }]
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_launch_intent.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_launch_intent.json
@@ -1,0 +1,3 @@
+{
+  "@type": "launch_intent"
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_shortcut.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_shortcut.json
@@ -1,0 +1,4 @@
+{
+  "@type": "shortcut",
+  "id": "my_shortcut_id"
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_shortcut_malformed.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_shortcut_malformed.json
@@ -1,0 +1,4 @@
+{
+  "@type": "shortcut",
+  "no_id": "my_shortcut_id"
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_test_installed_1.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_test_installed_1.json
@@ -1,0 +1,8 @@
+{
+  "@type": "test_installed",
+  "package": "io.branch.search.test",
+  "links": [{
+    "@type": "view_intent",
+    "data": "https://google.com"
+  }]
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_test_installed_2.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_test_installed_2.json
@@ -1,0 +1,8 @@
+{
+  "@type": "test_installed",
+  "package": "wrong.wrong.wrong",
+  "links": [{
+    "@type": "view_intent",
+    "data": "https://google.com"
+  }]
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_test_installed_malformed.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_test_installed_malformed.json
@@ -1,0 +1,4 @@
+{
+  "@type": "test_installed",
+  "no_package": "No package and no links - malformed!"
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_test_not_installed_1.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_test_not_installed_1.json
@@ -1,0 +1,8 @@
+{
+  "@type": "test_not_installed",
+  "package": "not.installed.package",
+  "links": [{
+    "@type": "view_intent",
+    "data": "https://google.com"
+  }]
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_test_not_installed_2.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_test_not_installed_2.json
@@ -1,0 +1,8 @@
+{
+  "@type": "test_not_installed",
+  "package": "io.branch.search.test",
+  "links": [{
+    "@type": "view_intent",
+    "data": "https://google.com"
+  }]
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_test_not_installed_malformed.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_test_not_installed_malformed.json
@@ -1,0 +1,4 @@
+{
+  "@type": "test_not_installed",
+  "no_package": "No package and no links - malformed!"
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_view_intent_1.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_view_intent_1.json
@@ -1,0 +1,8 @@
+{
+  "@type": "view_intent",
+  "data": "https://google.com",
+  "extras": {
+    "foo1": "bar1",
+    "foo2": "bar2"
+  }
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_view_intent_2.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_view_intent_2.json
@@ -1,0 +1,5 @@
+{
+  "@type": "view_intent",
+  "data": "wrongpackage://wrong.wrong",
+  "forcePackage": "com.wrong.package"
+}

--- a/BranchSearchSDK/src/androidTest/assets/handler_view_intent_malformed.json
+++ b/BranchSearchSDK/src/androidTest/assets/handler_view_intent_malformed.json
@@ -1,0 +1,4 @@
+{
+  "@type": "view_intent",
+  "no_data": "no data key."
+}

--- a/BranchSearchSDK/src/androidTest/assets/link_example.json
+++ b/BranchSearchSDK/src/androidTest/assets/link_example.json
@@ -1,0 +1,14 @@
+{
+  "name":"Fog\u00f3n Cocina Mexicana",
+  "score":0.9362279492598684,
+  "entity_id":"0ce185bd-6f89-4505-a452-e005ad7182a4",
+  "description":"Restaurant\n600 E Pine St, Seattle, WA\n",
+  "type":"Restaurant",
+  "image_url":"https://s3-media3.fl.yelpcdn.com/bphoto/lJoUuHgnkZ3_jslUhgw2qA/o.jpg",
+  "linking": [
+    {
+      "@type": "view_intent",
+      "data": "https://s3-media3.fl.yelpcdn.com/bphoto/lJoUuHgnkZ3_jslUhgw2qA/o.jpg"
+    }
+  ]
+}

--- a/BranchSearchSDK/src/androidTest/assets/success_mex_food.json
+++ b/BranchSearchSDK/src/androidTest/assets/success_mex_food.json
@@ -7,25 +7,10 @@
          "app_store_id":"com.yelp.android",
          "score":0.1441965701139767,
          "ranking_hint":"Trending near you",
-         "app_search_deep_link":{  
-            "name":null,
-            "uri_scheme":null,
-            "score":1.001,
-            "metadata":{  
-
-            },
-            "entity_id":8741903,
-            "web_link":"https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A%2F%2Fwww.yelp.com%2Fsearch%3Ffind_desc%3Dmexican&$ios_url=https%3A%2F%2Fwww.yelp.com%2Fsearch%3Ffind_desc%3Dmexican&$android_url=https%3A%2F%2Fwww.yelp.com%2Fsearch%3Ffind_desc%3Dmexican",
-            "description":null,
-            "type":"SearchQuery",
-            "image_url":null,
-            "routing_mode":"5"
-         },
          "app_name":"Yelp",
          "deep_links":[  
             {  
                "name":"Fog\u00f3n Cocina Mexicana",
-               "uri_scheme":null,
                "score":0.9362279492598684,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -46,15 +31,17 @@
                   "review_count":"1107"
                },
                "entity_id":"0ce185bd-6f89-4505-a452-e005ad7182a4",
-               "web_link":"https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$ios_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$android_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2",
                "description":"Restaurant\n600 E Pine St, Seattle, WA\n",
                "type":"Restaurant",
                "image_url":"https://s3-media3.fl.yelpcdn.com/bphoto/lJoUuHgnkZ3_jslUhgw2qA/o.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$ios_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$android_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2"
+               }]
             },
             {  
                "name":"El Borracho",
-               "uri_scheme":null,
                "score":0.9165558086371364,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -75,15 +62,17 @@
                   "review_count":"691"
                },
                "entity_id":"6d26cf52-395b-4ff0-a97d-4dc565ad3259",
-               "web_link":"https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/el-borracho-seattle&$ios_url=https%3A//www.yelp.com/biz/el-borracho-seattle&$android_url=https%3A//www.yelp.com/biz/el-borracho-seattle",
                "description":"Restaurant\n1521 1st Ave, Seattle, WA\n",
                "type":"Restaurant",
                "image_url":"https://s3-media4.fl.yelpcdn.com/bphoto/8B9nNUb2-pk11MwK1JXcQw/o.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$ios_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$android_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2"
+               }]
             },
             {  
                "name":"Mezcaleria Oaxaca",
-               "uri_scheme":null,
                "score":0.9009534489415987,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -104,15 +93,17 @@
                   "review_count":"286"
                },
                "entity_id":"1fc8ddf8-3560-4a32-844b-139ac325b526",
-               "web_link":"https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/mezcaleria-oaxaca-seattle-7&$ios_url=https%3A//www.yelp.com/biz/mezcaleria-oaxaca-seattle-7&$android_url=https%3A//www.yelp.com/biz/mezcaleria-oaxaca-seattle-7",
                "description":"Restaurant\n422 E Pine St, Seattle, WA\n",
                "type":"Restaurant",
                "image_url":"https://s3-media3.fl.yelpcdn.com/bphoto/6h57P9vrNwpxg2M5mIVK2A/o.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$ios_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$android_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2"
+               }]
             },
             {  
                "name":"Tacos Chukis",
-               "uri_scheme":null,
                "score":0.8994538108037511,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -133,11 +124,14 @@
                   "review_count":"1371"
                },
                "entity_id":"f9e47fee-9388-4054-b070-186d41f4e0e8",
-               "web_link":"https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/tacos-chukis-seattle&$ios_url=https%3A//www.yelp.com/biz/tacos-chukis-seattle&$android_url=https%3A//www.yelp.com/biz/tacos-chukis-seattle",
                "description":"Restaurant\n219 Broadway E, Seattle, WA\n",
                "type":"Restaurant",
                "image_url":"https://s3-media1.fl.yelpcdn.com/bphoto/AU2LRinK4hKGU7nnCTq73Q/o.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://yelp.to/a/key_live_cgf22Tbs1bynw5NsRXmyqhpexycE0FFF?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$ios_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2&$android_url=https%3A//www.yelp.com/biz/fog%25C3%25B3n-cocina-mexicana-seattle-2"
+               }]
             }
          ]
       },
@@ -146,25 +140,10 @@
          "app_store_id":"com.joelapenna.foursquared",
          "score":0.10016271011397673,
          "ranking_hint":"Trending near you",
-         "app_search_deep_link":{  
-            "name":null,
-            "uri_scheme":null,
-            "score":1.001,
-            "metadata":{  
-
-            },
-            "entity_id":8743282,
-            "web_link":"https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2Fexplore%3Fquery%3Dmexican&$fallback_url=https%3A%2F%2Ffoursquare.com%2Fexplore%3Fll%3D47.612797%252C-122.34612%26mode%3Durl%26q%3Dmexican",
-            "description":null,
-            "type":"SearchQuery",
-            "image_url":null,
-            "routing_mode":"5"
-         },
          "app_name":"Foursquare",
          "deep_links":[  
             {  
                "name":"Fog\u00f3n Cocina Mexicana",
-               "uri_scheme":null,
                "score":0.9362279492598684,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -185,15 +164,17 @@
                   "review_count":"385"
                },
                "entity_id":"0ce185bd-6f89-4505-a452-e005ad7182a4",
-               "web_link":"https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F4fe36e94e4b0391ded80a469&$fallback_url=https%3A//foursquare.com/v/4fe36e94e4b0391ded80a469",
                "description":"Restaurant\n600 E Pine St, Seattle, WA\nMexican Restaurant in Seattle, WA",
                "type":"Restaurant",
                "image_url":"https://igx.4sqi.net/img/general/600x600/10573445_61u5-PpHLQYxbZ_uTuMBptbMe535MaUWBEbWmdKlDzA.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F4fe36e94e4b0391ded80a469&$fallback_url=https%3A//foursquare.com/v/4fe36e94e4b0391ded80a469"
+               }]
             },
             {  
                "name":"El Borracho",
-               "uri_scheme":null,
                "score":0.9165558086371364,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -214,15 +195,17 @@
                   "review_count":"264"
                },
                "entity_id":"6d26cf52-395b-4ff0-a97d-4dc565ad3259",
-               "web_link":"https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F4fb68613e4b03322467127af&$fallback_url=https%3A//foursquare.com/v/4fb68613e4b03322467127af",
                "description":"Restaurant\n1521 1st Ave, Seattle, WA\nMexican Restaurant in Seattle, WA",
                "type":"Restaurant",
                "image_url":"https://igx.4sqi.net/img/general/600x600/38058087_3unCnFJDlCTYcu53UpuyzpcLLHX2MCxVxZ1U0GaXOx8.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F4fe36e94e4b0391ded80a469&$fallback_url=https%3A//foursquare.com/v/4fe36e94e4b0391ded80a469"
+               }]
             },
             {  
                "name":"Mezcaleria Oaxaca",
-               "uri_scheme":null,
                "score":0.9009534489415987,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -243,15 +226,17 @@
                   "review_count":"221"
                },
                "entity_id":"1fc8ddf8-3560-4a32-844b-139ac325b526",
-               "web_link":"https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F530dbb56498e841e9823bdf5&$fallback_url=https%3A//foursquare.com/v/530dbb56498e841e9823bdf5",
                "description":"Restaurant\n422 E Pine St, Seattle, WA\nMexican Restaurant in Seattle, WA",
                "type":"Restaurant",
                "image_url":"https://igx.4sqi.net/img/general/600x600/30338_-Ztqo5pgCjjwSdcUKdJo3YxKc5oIug3NSi7RMlVqO2o.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F4fe36e94e4b0391ded80a469&$fallback_url=https%3A//foursquare.com/v/4fe36e94e4b0391ded80a469"
+               }]
             },
             {  
                "name":"Tacos Chukis",
-               "uri_scheme":null,
                "score":0.8994538108037511,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -272,11 +257,14 @@
                   "review_count":"477"
                },
                "entity_id":"f9e47fee-9388-4054-b070-186d41f4e0e8",
-               "web_link":"https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F4d7ed31cebc15481e955e9a6&$fallback_url=https%3A//foursquare.com/v/4d7ed31cebc15481e955e9a6",
                "description":"Restaurant\n219 Broadway E, Seattle, WA\nTaco Place in Seattle, WA",
                "type":"Restaurant",
                "image_url":"https://igx.4sqi.net/img/general/600x600/712947_qqdjxspFMb9_8y3zjbnHORBDTMmSJ-CNwn4w7U0lUHE.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://to.4sq.com/a/key_live_nmm2Ae8J1GbSQXu22I7FTohhuwnTL9R0?$uri_redirect_mode=1&feature=branch_search&$deeplink_path=venues%2F4fe36e94e4b0391ded80a469&$fallback_url=https%3A//foursquare.com/v/4fe36e94e4b0391ded80a469"
+               }]
             }
          ]
       },
@@ -285,25 +273,10 @@
          "app_store_id":"com.postmates.android",
          "score":0.09806597744707996,
          "ranking_hint":"Trending near you",
-         "app_search_deep_link":{  
-            "name":null,
-            "uri_scheme":null,
-            "score":1.001,
-            "metadata":{  
-
-            },
-            "entity_id":8742353,
-            "web_link":"https://postmat.es/a/key_live_gdfSFGv9bguPWnP8D7JgHgmpCyen5mpZ?$uri_redirect_mode=1&feature=branch_search&$fallback_url=https%3A%2F%2Fpostmates.com%2Fsearch%3Fq%3Dmexican&$deeplink_path=v1%2Fsearch%3Fq%3Dmexican",
-            "description":null,
-            "type":"SearchQuery",
-            "image_url":null,
-            "routing_mode":"5"
-         },
          "app_name":"Postmates",
          "deep_links":[  
             {  
                "name":"Mezcaleria Oaxaca",
-               "uri_scheme":null,
                "score":0.9009534489415987,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -324,11 +297,14 @@
                   "review_count":null
                },
                "entity_id":"1fc8ddf8-3560-4a32-844b-139ac325b526",
-               "web_link":"https://postmat.es/a/key_live_gdfSFGv9bguPWnP8D7JgHgmpCyen5mpZ?$uri_redirect_mode=1&feature=branch_action_bar&$fallback_url=https%3A//postmates.com/merchant/mezcaleria-oaxaca-422-e-pine-st&$deeplink_path=v1%2Fplaces%2F5af041e5-26a7-4b8b-9979-3637e8675da0",
                "description":"Restaurant\n422 E Pine St, Seattle, WA\nOrder Delivery from Mezcaleria Oaxaca on 422 E Pine St, Seattle,",
                "type":"Restaurant",
                "image_url":"https://raster-static.postmates.com/?url=http%3A%2F%2Fcom.postmates.img.prod.s3.amazonaws.com%2Fa6d855fd-989c-43f6-b9b1-9e1d092a4651%2Forig.jpg&quality=85&mode=auto&format=jpg&v=4&w=1200&h=720",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://postmat.es/a/key_live_gdfSFGv9bguPWnP8D7JgHgmpCyen5mpZ?$uri_redirect_mode=1&feature=branch_action_bar&$fallback_url=https%3A//postmates.com/merchant/mezcaleria-oaxaca-422-e-pine-st&$deeplink_path=v1%2Fplaces%2F5af041e5-26a7-4b8b-9979-3637e8675da0"
+               }]
             }
          ]
       },
@@ -336,7 +312,6 @@
          "deep_links":[  
             {  
                "name":"South Park Mexican",
-               "uri_scheme":null,
                "score":0.48835992324626376,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -347,67 +322,79 @@
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://content-images.p-cdn.com/images/public/devicead/6/3/2/r/daar9609465r236_500W_500H.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.pandora.com/artist/south-park-mexican/ARmlZ355fPXJcrV"
+               }]
             },
             {  
                "name":"Mexican",
-               "uri_scheme":null,
                "score":0.46662673619590067,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.pandora.com/artist/various-artists/mexican/AL9ZmhK3bgqpJc4",
                "description":"Album | Various Artists\n",
                "type":"Album",
                "image_url":"https://content-images.p-cdn.com/images/public/amz/8/2/7/2/881226972728_500W_500H.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.pandora.com/artist/south-park-mexican/ARmlZ355fPXJcrV"
+               }]
             },
             {  
                "name":"Mexican Institute Of Sound",
-               "uri_scheme":null,
                "score":0.4388314936074935,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.pandora.com/artist/mexican-institute-of-sound/ARXnlcZlxkP52mK",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://content-images.p-cdn.com/images/public/rovi/portrait/3/9/4/5/MN0000975493_640W.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.pandora.com/artist/south-park-mexican/ARmlZ355fPXJcrV"
+               }]
             },
             {  
                "name":"Mexican Dubwiser",
-               "uri_scheme":null,
                "score":0.4165085542393785,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.pandora.com/artist/mexican-dubwiser/ARtj3J2zttJbmxk",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://content-images.p-cdn.com/images/public/int/0/5/1/0/655036180150_500W_500H.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.pandora.com/artist/south-park-mexican/ARmlZ355fPXJcrV"
+               }]
             },
             {  
                "name":"Mexican Radio",
-               "uri_scheme":null,
                "score":0.4029234728051,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.pandora.com/artist/mexican-radio/AR2hj4v6JvwnKP6",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://www.pandora.com/img/no_album_art.png",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.pandora.com/artist/south-park-mexican/ARmlZ355fPXJcrV"
+               }]
             }
          ],
          "app_name":"Pandora Music",
@@ -420,78 +407,88 @@
          "deep_links":[  
             {  
                "name":"Mexican Institute Of Sound",
-               "uri_scheme":null,
                "score":0.3285,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://open.spotify.com/artist/4TPTW3cTwUtiihgOMSQfmy",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://i.scdn.co/image/384d0464bc30a1121546d083e690051a550765b3",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://open.spotify.com/artist/4TPTW3cTwUtiihgOMSQfmy"
+               }]
             },
             {  
                "name":"Mexican Dress",
-               "uri_scheme":null,
                "score":0.24654,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://open.spotify.com/track/14OGS3byKHAdkeEN4wTxxn",
                "description":"Song | Blood Red Shoes\n",
                "type":"Song",
                "image_url":null,
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://open.spotify.com/artist/4TPTW3cTwUtiihgOMSQfmy"
+               }]
             },
             {  
                "name":"The Mexican",
-               "uri_scheme":null,
                "score":0.22596000000000002,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://open.spotify.com/track/6MssbPqsDjOmvuINzHKDNH",
                "description":"Song | GZA\n",
                "type":"Song",
                "image_url":null,
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://open.spotify.com/artist/4TPTW3cTwUtiihgOMSQfmy"
+               }]
             },
             {  
                "name":"Mexican Fender",
-               "uri_scheme":null,
                "score":0.22596000000000002,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://open.spotify.com/track/7LzdE75Ii1HLGWhhIJK4hD",
                "description":"Song | Weezer\n",
                "type":"Song",
                "image_url":null,
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://open.spotify.com/artist/4TPTW3cTwUtiihgOMSQfmy"
+               }]
             },
             {  
                "name":"Mexican Bean",
-               "uri_scheme":null,
                "score":0.21126000000000003,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://open.spotify.com/track/4kBGkavj8GDtDF7KD5Z3SD",
                "description":"Song | Mungo's Hi Fi\n",
                "type":"Song",
                "image_url":null,
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://open.spotify.com/artist/4TPTW3cTwUtiihgOMSQfmy"
+               }]
             }
          ],
          "app_name":"Spotify Music",
@@ -505,25 +502,10 @@
          "app_store_id":"com.opentable",
          "score":0.05088359394742512,
          "ranking_hint":"Trending near you",
-         "app_search_deep_link":{  
-            "name":null,
-            "uri_scheme":null,
-            "score":1.001,
-            "metadata":{  
-
-            },
-            "entity_id":8742718,
-            "web_link":"https://www.opentable.com/s/?latitude=47.612797&longitude=-122.34612&term=mexican",
-            "description":null,
-            "type":"SearchQuery",
-            "image_url":null,
-            "routing_mode":"5"
-         },
          "app_name":"OpenTable",
          "deep_links":[  
             {  
                "name":"Fog\u00f3n Cocina Mexicana",
-               "uri_scheme":null,
                "score":0.9362279492598684,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -544,15 +526,17 @@
                   "review_count":null
                },
                "entity_id":"0ce185bd-6f89-4505-a452-e005ad7182a4",
-               "web_link":"https://www.opentable.com/rest_profile_menu.aspx?rid=101761",
                "description":"Restaurant\n600 E Pine St, Seattle, WA\nWe are a family based restaurant with origins in Michoac\u00e1n, Mexi",
                "type":"Restaurant",
                "image_url":"https://resizer.otstatic.com/v2/photos/small/23665685.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.opentable.com/rest_profile_menu.aspx?rid=101761"
+               }]
             },
             {  
                "name":"El Borracho",
-               "uri_scheme":null,
                "score":0.9165558086371364,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -573,11 +557,14 @@
                   "review_count":null
                },
                "entity_id":"6d26cf52-395b-4ff0-a97d-4dc565ad3259",
-               "web_link":"https://www.opentable.com/el-borracho-seattle",
                "description":"Restaurant\n1521 1st Ave, Seattle, WA\n<p>El Borracho, a hip and fresh taqueria in Seattle's Pike Place",
                "type":"Restaurant",
                "image_url":null,
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.opentable.com/rest_profile_menu.aspx?rid=101761"
+               }]
             }
          ]
       },
@@ -585,7 +572,6 @@
          "deep_links":[  
             {  
                "name":"Fogon Cocina Mexicana",
-               "uri_scheme":"tripadvisor://tripadvisor.com/Restaurant_Review-g60878-d463480-Reviews-The_Green_Papaya-Seattle_Washington",
                "score":0.9362279492598684,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -606,15 +592,17 @@
                   "review_count":"135"
                },
                "entity_id":"0ce185bd-6f89-4505-a452-e005ad7182a4",
-               "web_link":"http://www.tripadvisor.com/Restaurant_Review-g60878-d463480-Reviews-The_Green_Papaya-Seattle_Washington.html",
                "description":"Restaurant\n600 E Pine St, Seattle, WA\nFogon Cocina Mexicana, Seattle: See 135 unbiased reviews of Fogo",
                "type":"Restaurant",
                "image_url":"https://media-cdn.tripadvisor.com/media/photo-s/07/ac/f1/79/fogon-cocina-mexicana.jpg",
-               "routing_mode":"5"
+               "routing_mode":"5",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "http://www.tripadvisor.com/Restaurant_Review-g60878-d463480-Reviews-The_Green_Papaya-Seattle_Washington.html"
+               }]
             },
             {  
                "name":"Mezcaleria Oaxaca",
-               "uri_scheme":"tripadvisor://tripadvisor.com/Restaurant_Review-g60878-d6615981-Reviews-Mezcaleria_Oaxaca-Seattle_Washington",
                "score":0.9009534489415987,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -635,15 +623,17 @@
                   "review_count":"40"
                },
                "entity_id":"1fc8ddf8-3560-4a32-844b-139ac325b526",
-               "web_link":"https://www.tripadvisor.com/Restaurant_Review-g60878-d6615981-Reviews-Mezcaleria_Oaxaca-Seattle_Washington.html",
                "description":"Restaurant\n422 E Pine St, Seattle, WA\nMezcaleria Oaxaca, Seattle: See 40 unbiased reviews of Mezcaleri",
                "type":"Restaurant",
                "image_url":"https://media-cdn.tripadvisor.com/media/photo-s/0e/d9/26/c4/photo1jpg.jpg",
-               "routing_mode":"5"
+               "routing_mode":"5",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "http://www.tripadvisor.com/Restaurant_Review-g60878-d463480-Reviews-The_Green_Papaya-Seattle_Washington.html"
+               }]
             },
             {  
                "name":"Tacos Chukis",
-               "uri_scheme":"tripadvisor://tripadvisor.com/Restaurant_Review-g60878-d2373315-Reviews-Tacos_Chukis-Seattle_Washington",
                "score":0.8994538108037511,
                "ranking_hint":"Trending near you",
                "metadata":{  
@@ -664,11 +654,14 @@
                   "review_count":"52"
                },
                "entity_id":"f9e47fee-9388-4054-b070-186d41f4e0e8",
-               "web_link":"http://www.tripadvisor.com/Restaurant_Review-g60878-d2373315-Reviews-Tacos_Chukis-Seattle_Washington.html",
                "description":"Restaurant\n219 Broadway E, Seattle, WA\nTacos Chukis, Seattle: See 52 unbiased reviews of Tacos Chukis, ",
                "type":"Restaurant",
                "image_url":"https://media-cdn.tripadvisor.com/media/photo-s/07/2a/1a/8e/tacos-chukis.jpg",
-               "routing_mode":"5"
+               "routing_mode":"5",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "http://www.tripadvisor.com/Restaurant_Review-g60878-d463480-Reviews-The_Green_Papaya-Seattle_Washington.html"
+               }]
             }
          ],
          "app_name":"Tripadvisor",
@@ -681,78 +674,88 @@
          "deep_links":[  
             {  
                "name":"South Park Mexican",
-               "uri_scheme":null,
                "score":0.4252970458708841,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://music.amazon.com/artists/B000QJVA0Y",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://images-na.ssl-images-amazon.com/images/G/01/digital/music/webcomponents/ogre/OpenGraphDefault_new_logo._V516206468_.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://music.amazon.com/artists/B000QJVA0Y"
+               }]
             },
             {  
                "name":"Mexican Border Brass Ensemble",
-               "uri_scheme":null,
                "score":0.33441566056967686,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://music.amazon.com/artists/B001D5DB2A",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://images-na.ssl-images-amazon.com/images/G/01/digital/music/webcomponents/ogre/OpenGraphDefault_new_logo._V516206468_.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://music.amazon.com/artists/B000QJVA0Y"
+               }]
             },
             {  
                "name":"Mexican Institute Of Sound",
-               "uri_scheme":null,
                "score":0.33441566056967686,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://music.amazon.com/artists/B000QKIILC",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://images-na.ssl-images-amazon.com/images/G/01/digital/music/webcomponents/ogre/OpenGraphDefault_new_logo._V516206468_.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://music.amazon.com/artists/B000QJVA0Y"
+               }]
             },
             {  
                "name":"Mexican",
-               "uri_scheme":null,
                "score":0.3,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://music.amazon.com/artists/B001N3V90I",
                "description":"Artist",
                "type":"Artist",
                "image_url":"https://images-na.ssl-images-amazon.com/images/G/01/digital/music/webcomponents/ogre/OpenGraphDefault_new_logo._V516206468_.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://music.amazon.com/artists/B000QJVA0Y"
+               }]
             },
             {  
                "name":"Mexican Fender",
-               "uri_scheme":null,
                "score":0.27139697216682984,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://music.amazon.com/albums/B074Q31SCL?do=play&trackAsin=B074Q34CDC",
                "description":"Song | Weezer\n",
                "type":"Song",
                "image_url":"https://m.media-amazon.com/images/I/61IsCvnr05L._US510_SR1200,630_BG34,43,59_PJamznMusicLogoSticker1x,TopLeft,60,60_OU11_.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://music.amazon.com/artists/B000QJVA0Y"
+               }]
             }
          ],
          "app_name":"Amazon Music",
@@ -765,78 +768,88 @@
          "deep_links":[  
             {  
                "name":"Mexican Fender",
-               "uri_scheme":null,
                "score":0.3752489854852146,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.saavn.com/s/song/english/Mexican-Fender/Mexican-Fender/FAk4SDMIAEA",
                "description":"Song | Weezer\n",
                "type":"Song",
                "image_url":"https://c.saavncdn.com/556/Mexican-Fender-English-2017-20170811180247-500x500.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.saavn.com/s/song/english/Mexican-Fender/Mexican-Fender/FAk4SDMIAEA"
+               }]
             },
             {  
                "name":"Mexican Lingo",
-               "uri_scheme":null,
                "score":0.2951432016397042,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.saavn.com/s/album/english/Mexican-Lingo-2013/YY1x5bC3ejE",
                "description":"Album | Future\n",
                "type":"Album",
                "image_url":"https://c.saavncdn.com/969/Mexican-Lingo-English-2013-500x500.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.saavn.com/s/song/english/Mexican-Fender/Mexican-Fender/FAk4SDMIAEA"
+               }]
             },
             {  
                "name":"Mexican Joe",
-               "uri_scheme":null,
                "score":0.2793499249601316,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.saavn.com/s/album/english/Mexican-Joe-2011/95aHM-YAEm0",
                "description":"Album | Jim Reeves\n",
                "type":"Album",
                "image_url":"https://c.saavncdn.com/658/Mexican-Joe-English-2011-500x500.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.saavn.com/s/song/english/Mexican-Fender/Mexican-Fender/FAk4SDMIAEA"
+               }]
             },
             {  
                "name":"Mexican Joe",
-               "uri_scheme":null,
                "score":0.2793499249601316,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.saavn.com/s/album/english/Mexican-Joe-2008/dSkXTnXZxes",
                "description":"Album | Jim Reeves\n",
                "type":"Album",
                "image_url":"https://c.saavncdn.com/235/Mexican-Joe-English-2008-500x500.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.saavn.com/s/song/english/Mexican-Fender/Mexican-Fender/FAk4SDMIAEA"
+               }]
             },
             {  
                "name":"Mexican",
-               "uri_scheme":null,
                "score":0.23825899241458112,
                "ranking_hint":"Trending near you",
                "metadata":{  
 
                },
                "entity_id":null,
-               "web_link":"https://www.saavn.com/s/song/english/George-Kush-da-Button:-Dont-Pass-Trump-the-Blunt/Mexican/LxxYAxBFVHo",
                "description":"Song | Smoke Dza\n",
                "type":"Song",
                "image_url":"https://c.saavncdn.com/543/George-Kush-da-Button-Don-t-Pass-Trump-the-Blunt-English-2016-500x500.jpg",
-               "routing_mode":"6"
+               "routing_mode":"6",
+               "linking": [{
+                  "@type": "view_intent",
+                  "data": "https://www.saavn.com/s/song/english/Mexican-Fender/Mexican-Fender/FAk4SDMIAEA"
+               }]
             }
          ],
          "app_name":"Saavn Music & Radio",

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkHandlerTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkHandlerTest.java
@@ -1,0 +1,225 @@
+package io.branch.search;
+
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.test.espresso.intent.Intents;
+import android.support.test.espresso.intent.matcher.IntentMatchers;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import io.branch.search.util.AssetUtils;
+
+/**
+ * {@link BranchLinkHandler} tests.
+ */
+@RunWith(AndroidJUnit4.class)
+public class BranchLinkHandlerTest extends BranchTest {
+
+    private BranchLinkResult link;
+    private IBranchShortcutHandler externalShortutHandler;
+    private IBranchDeepViewHandler externalDeepViewHandler;
+
+    @Before
+    public void setUp() throws Throwable {
+        super.setUp();
+        externalShortutHandler = Mockito.mock(IBranchShortcutHandler.class);
+        externalDeepViewHandler = Mockito.mock(IBranchDeepViewHandler.class);
+        BranchConfiguration configuration = new BranchConfiguration();
+        configuration.setShortcutHandler(externalShortutHandler);
+        configuration.setDeepViewHandler(externalDeepViewHandler);
+        initBranch(configuration);
+
+        JSONObject linkJson = load("link_example");
+        link = BranchLinkResult.createFromJson(linkJson, "Sample App",
+                "com.sample", "", "");
+        Assert.assertNotNull(link);
+
+        Intents.init();
+    }
+
+    @After
+    public void tearDown() {
+        super.tearDown();
+        Intents.release();
+    }
+
+    @NonNull
+    private JSONObject load(@NonNull String name) throws JSONException  {
+        return new JSONObject(AssetUtils.readJsonFile(getTestContext(), name + ".json"));
+    }
+
+    @Test(expected = JSONException.class)
+    public void testShortcut_malformed() throws JSONException {
+        JSONObject json = load("handler_shortcut_malformed");
+        BranchLinkHandler.from(json);
+    }
+
+    @Test
+    public void testShortcut_validate() throws JSONException {
+        JSONObject json = load("handler_shortcut");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        handler.validate(getTestContext(), link);
+        Mockito.verify(externalShortutHandler, Mockito.times(1))
+                .validateShortcut(Mockito.eq(getTestContext()), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test
+    public void testShortcut_open() throws JSONException {
+        JSONObject json = load("handler_shortcut");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        handler.open(getTestContext(), link);
+        Mockito.verify(externalShortutHandler, Mockito.times(1))
+                .launchShortcut(Mockito.eq(getTestContext()), Mockito.anyString(), Mockito.anyString());
+    }
+
+    @Test(expected = JSONException.class)
+    public void testViewIntent_malformed() throws JSONException {
+        JSONObject json = load("handler_view_intent_malformed");
+        BranchLinkHandler.from(json);
+    }
+
+    @Test
+    public void testViewIntent_validate() throws JSONException {
+        JSONObject json1 = load("handler_view_intent_1");
+        JSONObject json2 = load("handler_view_intent_2");
+        BranchLinkHandler handler1 = BranchLinkHandler.from(json1);
+        BranchLinkHandler handler2 = BranchLinkHandler.from(json2);
+        Assert.assertTrue(handler1.validate(getTestContext(), link));
+        Assert.assertFalse(handler2.validate(getTestContext(), link));
+    }
+
+    @Test
+    public void testViewIntent_open() throws JSONException {
+        JSONObject json = load("handler_view_intent_1");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Assert.assertTrue(handler.open(getTestContext(), link));
+        Intents.intended(IntentMatchers.hasAction(Intent.ACTION_VIEW));
+        Intents.intended(IntentMatchers.hasExtra("foo1", "bar1"));
+        Intents.intended(IntentMatchers.hasExtra("foo2", "bar2"));
+    }
+
+    @Test
+    public void testLaunchIntent_validate() throws JSONException {
+        // launch_intent takes the target package name from the link.
+        // We made it up, so validation should fail.
+        JSONObject json = load("handler_launch_intent");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Assert.assertFalse(handler.validate(getTestContext(), link));
+    }
+
+    @Test
+    public void testLaunchIntent_open() throws JSONException {
+        // launch_intent takes the target package name from the link.
+        // We made it up, so opening should fail. It won't be able to find the launch intent.
+        JSONObject json = load("handler_launch_intent");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Assert.assertFalse(handler.open(getTestContext(), link));
+        Intents.assertNoUnverifiedIntents();
+    }
+
+    @Test(expected = JSONException.class)
+    public void testCustomIntent_malformed() throws JSONException {
+        JSONObject json = load("handler_custom_intent_malformed");
+        BranchLinkHandler.from(json);
+    }
+
+    @Test
+    public void testCustomIntent_validate() throws JSONException {
+        JSONObject json = load("handler_custom_intent");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Assert.assertTrue(handler.validate(getTestContext(), link));
+    }
+
+    @Test
+    public void testCustomIntent_open() throws JSONException {
+        JSONObject json = load("handler_custom_intent");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Assert.assertTrue(handler.open(getTestContext(), link));
+        Intents.intended(IntentMatchers.hasAction("android.settings.SETTINGS"));
+        Intents.intended(IntentMatchers.hasExtra("foo1", "bar1"));
+        Intents.intended(IntentMatchers.hasExtra("foo2", "bar2"));
+    }
+
+    @Test(expected = JSONException.class)
+    public void testTestInstalled_malformed() throws JSONException {
+        JSONObject json = load("handler_test_installed_malformed");
+        BranchLinkHandler.from(json);
+    }
+
+    @Test
+    public void testTestInstalled_validate() throws JSONException {
+        JSONObject json1 = load("handler_test_installed_1");
+        JSONObject json2 = load("handler_test_installed_2");
+        BranchLinkHandler handler1 = BranchLinkHandler.from(json1);
+        BranchLinkHandler handler2 = BranchLinkHandler.from(json2);
+        Assert.assertTrue(handler1.validate(getTestContext(), link));
+        Assert.assertFalse(handler2.validate(getTestContext(), link));
+    }
+
+    @Test
+    public void testTestInstalled_open() throws JSONException {
+        JSONObject json = load("handler_test_installed_1");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Assert.assertTrue(handler.open(getTestContext(), link));
+        Intents.intended(IntentMatchers.hasAction(Intent.ACTION_VIEW));
+        Intents.intended(IntentMatchers.hasData("https://google.com"));
+    }
+
+    @Test(expected = JSONException.class)
+    public void testTestNotInstalled_malformed() throws JSONException {
+        JSONObject json = load("handler_test_not_installed_malformed");
+        BranchLinkHandler.from(json);
+    }
+
+    @Test
+    public void testTestNotInstalled_validate() throws JSONException {
+        JSONObject json1 = load("handler_test_not_installed_1");
+        JSONObject json2 = load("handler_test_not_installed_2");
+        BranchLinkHandler handler1 = BranchLinkHandler.from(json1);
+        BranchLinkHandler handler2 = BranchLinkHandler.from(json2);
+        Assert.assertTrue(handler1.validate(getTestContext(), link));
+        Assert.assertFalse(handler2.validate(getTestContext(), link));
+    }
+
+    @Test
+    public void testTestNotInstalled_open() throws JSONException {
+        JSONObject json = load("handler_test_not_installed_1");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Assert.assertTrue(handler.open(getTestContext(), link));
+        Intents.intended(IntentMatchers.hasAction(Intent.ACTION_VIEW));
+        Intents.intended(IntentMatchers.hasData("https://google.com"));
+    }
+
+    @Test
+    public void testDeepView_validate() throws JSONException {
+        // deep_view handler is valid if child handlers are valid.
+        JSONObject json1 = load("handler_deep_view_1");
+        JSONObject json2 = load("handler_deep_view_2");
+        BranchLinkHandler handler1 = BranchLinkHandler.from(json1);
+        BranchLinkHandler handler2 = BranchLinkHandler.from(json2);
+        Assert.assertTrue(handler1.validate(getTestContext(), link));
+        Assert.assertFalse(handler2.validate(getTestContext(), link));
+    }
+
+    @Test
+    public void testDeepView_open() throws JSONException {
+        JSONObject json = load("handler_deep_view_1");
+        BranchLinkHandler handler = BranchLinkHandler.from(json);
+        Mockito.when(externalDeepViewHandler.launchDeepView(
+                Mockito.eq(getTestContext()),
+                Mockito.any(BranchDeepViewFragment.class))
+        ).thenReturn(true);
+        Assert.assertTrue(handler.open(getTestContext(), link));
+        Mockito.verify(externalDeepViewHandler, Mockito.times(1)).launchDeepView(
+                Mockito.eq(getTestContext()),
+                Mockito.any(BranchDeepViewFragment.class));
+    }
+}

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkResultTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkResultTest.java
@@ -1,13 +1,15 @@
 package io.branch.search;
 
-import android.content.Intent;
 import android.os.Parcel;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import io.branch.search.util.AssetUtils;
 
 /**
  * BranchLinkResult class tests.
@@ -16,10 +18,10 @@ import org.junit.runner.RunWith;
 public class BranchLinkResultTest extends BranchTest {
 
     @Test
-    public void testParcelable_keepsEmptyStrings() {
-        // Create a BranchLinkResult that's as empty as possible - from empty JSON
-        JSONObject empty = new JSONObject();
-        BranchLinkResult link1 = BranchLinkResult.createFromJson(empty,
+    public void testParcelable_keepsEmptyStrings() throws JSONException  {
+        // Create a BranchLinkResult from sample JSON
+        JSONObject json = new JSONObject(AssetUtils.readJsonFile(getTestContext(), "link_example.json"));
+        BranchLinkResult link1 = BranchLinkResult.createFromJson(json,
                 "appName", "appStoreId", "appIconUrl", "");
         Assert.assertNotNull(link1);
 

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkResultTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchLinkResultTest.java
@@ -20,7 +20,7 @@ public class BranchLinkResultTest extends BranchTest {
         // Create a BranchLinkResult that's as empty as possible - from empty JSON
         JSONObject empty = new JSONObject();
         BranchLinkResult link1 = BranchLinkResult.createFromJson(empty,
-                "appName", "appStoreId", "appIconUrl", "", true);
+                "appName", "appStoreId", "appIconUrl", "");
         Assert.assertNotNull(link1);
 
         // Ensure missing fields are actually ""s, and the others were correctly set.

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchResultTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchSearchResultTest.java
@@ -135,7 +135,6 @@ public class BranchSearchResultTest extends BranchTest {
         Assert.assertTrue(link.getScore() >= 0.0f);
         Assert.assertNotNull(link.getMetadata());
         Assert.assertNotNull(link.getRoutingMode());
-        Assert.assertNotNull(link.getWebLink());
         Assert.assertNotNull(link.getDestinationPackageName());
         Assert.assertNotNull(link.getClickTrackingUrl());
         Assert.assertNotNull(link.getRankingHint());

--- a/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchTest.java
+++ b/BranchSearchSDK/src/androidTest/java/io/branch/search/BranchTest.java
@@ -19,7 +19,6 @@ import io.branch.search.mock.MockActivity;
 /**
  * Base Instrumented test, which will execute on an Android device.
  */
-@RunWith(AndroidJUnit4.class)
 public class BranchTest {
     private Context mContext;
     private Activity mActivity;
@@ -39,26 +38,6 @@ public class BranchTest {
         mContext = null;
         mActivity.finish();
         mActivity = null;
-    }
-
-    @Test
-    public void testAppContext() {
-        // Context of the app under test.
-        Assert.assertNotNull(getTestContext());
-
-        // Context of the app as an Activity
-        Assert.assertNotNull(getUIContext());
-
-        // The two Context Objects are theoretically not the same
-        Assert.assertNotSame(getTestContext(), getUIContext());
-    }
-
-    @Test
-    public void testPackageName() {
-        // Context of the app under test.
-        Context appContext = getTestContext();
-
-        Assert.assertEquals("io.branch.search.test", appContext.getPackageName());
     }
 
     /**

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchAppResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchAppResult.java
@@ -198,8 +198,7 @@ public class BranchAppResult implements Parcelable {
                         name,
                         packageName,
                         iconUrl,
-                        deepviewExtraText,
-                        isInstalled);
+                        deepviewExtraText);
                 if (link != null) {
                     links.add(link);
                 }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchConfiguration.java
@@ -42,6 +42,7 @@ public class BranchConfiguration {
     private int intentFlags = Intent.FLAG_ACTIVITY_NEW_TASK;
     private final Map<String, Object> requestExtra = new HashMap<>();
     private IBranchShortcutHandler shortcutHandler = IBranchShortcutHandler.DEFAULT;
+    private IBranchDeepViewHandler deepViewHandler = IBranchDeepViewHandler.DEFAULT;
 
     // JSONKeys associated with a Configuration
     enum JSONKey {
@@ -325,6 +326,29 @@ public class BranchConfiguration {
     @NonNull
     public IBranchShortcutHandler getShortcutHandler() {
         return shortcutHandler;
+    }
+
+    /**
+     * Override the default deepview handler to validate and launch Deep Views.
+     * @param deepViewHandler handler to use
+     * @return this BranchConfiguration
+     */
+    @SuppressWarnings({"WeakerAccess", "unused"})
+    @NonNull
+    public BranchConfiguration setDeepViewHandler(@NonNull IBranchDeepViewHandler deepViewHandler) {
+        this.deepViewHandler = deepViewHandler;
+        return this;
+    }
+
+    /**
+     * Returns the deepview handler.
+     * @see #setDeepViewHandler(IBranchDeepViewHandler)
+     * @return the deepview handler
+     */
+    @SuppressWarnings("WeakerAccess")
+    @NonNull
+    public IBranchDeepViewHandler getDeepViewHandler() {
+        return deepViewHandler;
     }
 
     /**

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkHandler.java
@@ -349,7 +349,7 @@ abstract class BranchLinkHandler implements Parcelable {
         private final static String KEY_DESCRIPTION = "description";
         private final static String KEY_IMAGE_URL = "image_url";
         // TODO cta text ?
-        // TODO put deepview_extra_text here instead of link ?
+        // TODO put deepview_extra_text here instead of link level ?
 
         private final String imageUrl;
         private final String title;

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkHandler.java
@@ -1,0 +1,195 @@
+package io.branch.search;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+abstract class BranchLinkHandler implements Parcelable {
+
+    @NonNull
+    static BranchLinkHandler from(@NonNull JSONObject payload) throws JSONException {
+        String type = payload.getString("@type");
+        switch (type) {
+            case "view_intent": return new ViewIntent(payload);
+            case "launch_intent": return new LaunchIntent(payload);
+            case "shortcut": return new Shortcut(payload);
+            default: throw new JSONException("Unknown type!");
+        }
+    }
+
+    private final String payloadString;
+
+    protected BranchLinkHandler(@NonNull JSONObject payload) {
+        payloadString = payload.toString();
+    }
+
+    abstract boolean validate(@NonNull Context context, @NonNull String appPackageName);
+
+    abstract boolean open(@NonNull Context context, @NonNull String appPackageName);
+
+    @Override
+    public final void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(payloadString);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public final static Creator<BranchLinkHandler> CREATOR = new Creator<BranchLinkHandler>() {
+        @Override
+        public BranchLinkHandler createFromParcel(Parcel source) {
+            try {
+                return from(new JSONObject(source.readString()));
+            } catch (JSONException e) {
+                throw new RuntimeException("Can't happen!");
+            }
+        }
+
+        @Override
+        public BranchLinkHandler[] newArray(int size) {
+            return new BranchLinkHandler[size];
+        }
+    };
+
+    /**
+     * The view_intent handler, opening an Uri and optionally forcing the target package.
+     */
+    private static class ViewIntent extends BranchLinkHandler {
+        private final static String KEY_DATA = "data";
+        private final static String KEY_TARGET = "forcePackage";
+        private final static String KEY_EXTRAS = "extras";
+
+        private final Uri data;
+        private final String target;
+        private final Map<String, String> extras = new HashMap<>();
+
+        private ViewIntent(@NonNull JSONObject payload) throws JSONException {
+            super(payload);
+            data = Uri.parse(payload.getString(KEY_DATA));
+            target = payload.has(KEY_TARGET) ? payload.getString(KEY_TARGET) : null;
+            if (payload.has(KEY_EXTRAS)) {
+                JSONObject extras = payload.getJSONObject(KEY_EXTRAS);
+                Iterator<String> keys = extras.keys();
+                while (keys.hasNext()) {
+                    String key = keys.next();
+                    this.extras.put(key, extras.getString(key));
+                }
+            }
+        }
+
+        @Override
+        boolean validate(@NonNull Context context, @NonNull String appPackageName) {
+            if (target != null && !Util.isAppInstalled(context, target)) return false;
+            Intent intent = new Intent(Intent.ACTION_VIEW, data);
+            if (target != null) intent.setPackage(target); // no need to add extras here.
+            return !context.getPackageManager().queryIntentActivities(intent, 0).isEmpty();
+        }
+
+        @Override
+        boolean open(@NonNull Context context, @NonNull String appPackageName) {
+            Intent intent = new Intent(Intent.ACTION_VIEW, data);
+            if (target != null) intent.setPackage(target);
+            for (String extra : extras.keySet()) {
+                intent.putExtra(extra, extras.get(extra));
+            }
+            intent.setFlags(BranchSearch.getInstance()
+                    .getBranchConfiguration()
+                    .getLaunchIntentFlags());
+            try {
+                context.startActivity(intent);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * The launch_intent handler, opening an app with
+     * {@link android.content.pm.PackageManager#getLaunchIntentForPackage(String)}.
+     */
+    private static class LaunchIntent extends BranchLinkHandler {
+        private final static String KEY_EXTRAS = "extras";
+
+        private final Map<String, String> extras = new HashMap<>();
+
+        private LaunchIntent(@NonNull JSONObject payload) throws JSONException {
+            super(payload);
+            if (payload.has(KEY_EXTRAS)) {
+                JSONObject extras = payload.getJSONObject(KEY_EXTRAS);
+                Iterator<String> keys = extras.keys();
+                while (keys.hasNext()) {
+                    String key = keys.next();
+                    this.extras.put(key, extras.getString(key));
+                }
+            }
+        }
+
+        @Override
+        boolean validate(@NonNull Context context, @NonNull String appPackageName) {
+            return context.getPackageManager().getLaunchIntentForPackage(appPackageName) != null;
+        }
+
+        @Override
+        boolean open(@NonNull Context context, @NonNull String appPackageName) {
+            Intent intent = context.getPackageManager().getLaunchIntentForPackage(appPackageName);
+            if (intent == null) return false; // App uninstalled after validation!
+            for (String extra : extras.keySet()) {
+                intent.putExtra(extra, extras.get(extra));
+            }
+            // addFlags instead of setFlags, to ensure we don't override anything important.
+            intent.addFlags(BranchSearch.getInstance()
+                    .getBranchConfiguration()
+                    .getLaunchIntentFlags());
+            try {
+                context.startActivity(intent);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * The "shortcut" handler, opening an Android shortcut if possible.
+     * This actually delegates everything to the public {@link IBranchShortcutHandler}.
+     */
+    private static class Shortcut extends BranchLinkHandler {
+        private final static String KEY_ID = "id";
+
+        private final String id;
+
+        private Shortcut(@NonNull JSONObject payload) throws JSONException {
+            super(payload);
+            id = payload.getString(KEY_ID);
+        }
+
+        @Override
+        boolean validate(@NonNull Context context, @NonNull String appPackageName) {
+            IBranchShortcutHandler handler = BranchSearch.getInstance()
+                    .getBranchConfiguration()
+                    .getShortcutHandler();
+            return handler.validateShortcut(context, id, appPackageName);
+        }
+
+        @Override
+        boolean open(@NonNull Context context, @NonNull String appPackageName) {
+            IBranchShortcutHandler handler = BranchSearch.getInstance()
+                    .getBranchConfiguration()
+                    .getShortcutHandler();
+            return handler.launchShortcut(context, id, appPackageName);
+        }
+    }
+}

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkHandler.java
@@ -103,16 +103,19 @@ abstract class BranchLinkHandler implements Parcelable {
     private static class ViewIntent extends BranchLinkHandler {
         private final static String TYPE = "view_intent";
         private final static String KEY_DATA = "data";
+        private final static String KEY_ACTION = "action";
         private final static String KEY_TARGET = "forcePackage";
         private final static String KEY_EXTRAS = "extras";
 
         private final Uri data;
         private final String target;
+        private final String action;
         private final Map<String, String> extras = new HashMap<>();
 
         private ViewIntent(@NonNull JSONObject payload) throws JSONException {
             super(payload);
             data = Uri.parse(payload.getString(KEY_DATA));
+            action = payload.optString(KEY_ACTION, Intent.ACTION_VIEW);
             target = payload.has(KEY_TARGET) ? payload.getString(KEY_TARGET) : null;
             if (payload.has(KEY_EXTRAS)) {
                 JSONObject extras = payload.getJSONObject(KEY_EXTRAS);
@@ -127,14 +130,14 @@ abstract class BranchLinkHandler implements Parcelable {
         @Override
         boolean validate(@NonNull Context context, @NonNull BranchLinkResult parent) {
             if (target != null && !Util.isAppInstalled(context, target)) return false;
-            Intent intent = new Intent(Intent.ACTION_VIEW, data);
+            Intent intent = new Intent(action, data);
             if (target != null) intent.setPackage(target); // no need to add extras here.
             return !context.getPackageManager().queryIntentActivities(intent, 0).isEmpty();
         }
 
         @Override
         boolean open(@NonNull Context context, @NonNull BranchLinkResult parent) {
-            Intent intent = new Intent(Intent.ACTION_VIEW, data);
+            Intent intent = new Intent(action, data);
             if (target != null) intent.setPackage(target);
             for (String extra : extras.keySet()) {
                 intent.putExtra(extra, extras.get(extra));

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -104,14 +104,17 @@ public class BranchLinkResult implements Parcelable {
         return entity_id;
     }
 
+    @NonNull
     public String getName() {
         return name;
     }
 
+    @NonNull
     public String getDescription() {
         return description;
     }
 
+    @NonNull
     public String getImageUrl() {
         return image_url;
     }

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -330,18 +330,13 @@ public class BranchLinkResult implements Parcelable {
     @Nullable
     public BranchSearchError open(@NonNull Context context) {
         registerClickEvent();
-        boolean open = false;
         for (BranchLinkHandler handler : handlers) {
             // let's validate again before opening: something might have changed.
-            open = handler.validate(context, this)
+            boolean open = handler.validate(context, this)
                     && handler.open(context, this);
-            if (open) break;
+            if (open) return null;
         }
-        if (open) {
-            return null;
-        } else {
-            return new BranchSearchError(BranchSearchError.ERR_CODE.ROUTING_ERR_UNABLE_TO_OPEN_APP);
-        }
+        return new BranchSearchError(BranchSearchError.ERR_CODE.ROUTING_ERR_UNABLE_TO_OPEN_APP);
     }
 
     @SuppressLint("NewApi")
@@ -389,15 +384,10 @@ public class BranchLinkResult implements Parcelable {
         boolean canHandle = false;
         for (BranchLinkHandler handler : link.handlers) {
             if (handler.validate(context, link)) {
-                canHandle = true;
-                break;
+                return link;
             }
         }
-        if (!canHandle) {
-            return null;
-        } else {
-            return link;
-        }
+        return null;
     }
 
     @Override

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -15,12 +15,15 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.text.TextUtils;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * Class for representing a a deep link to content
@@ -72,14 +75,12 @@ public class BranchLinkResult implements Parcelable {
     private static final String LINK_DESC_KEY = "description";
     private static final String LINK_IMAGE_URL_KEY = "image_url";
     private static final String LINK_METADATA_KEY = "metadata";
-    private static final String LINK_URI_SCHEME_KEY = "uri_scheme";
-    private static final String LINK_WEB_LINK_KEY = "web_link";
     private static final String LINK_ROUTING_MODE_KEY = "routing_mode";
     private static final String LINK_TRACKING_KEY = "click_tracking_link";
     private static final String LINK_RANKING_HINT_KEY = "ranking_hint";
-    private static final String LINK_ANDROID_SHORTCUT_ID_KEY = "android_shortcut_id";
     private static final String LINK_ICON_CATEGORY = "icon_category";
     private static final String LINK_DEEPVIEW_EXTRA_TEXT_KEY = "deepview_extra_text";
+    private static final String LINK_HANDLERS = "linking";
 
     private String entity_id;
     private String name;
@@ -91,19 +92,17 @@ public class BranchLinkResult implements Parcelable {
     private JSONObject metadata;
     private String type;
     private float score;
-
     private String routing_mode;
-    private String uri_scheme;
-    String web_link; /* read by BranchResponseParser */
     private String destination_store_id;
     private String click_tracking_url;
-    private String android_shortcut_id;
     private String icon_category;
     String deepview_extra_text; /* read by BranchDeepViewFragment */
+    private final List<BranchLinkHandler> handlers = new ArrayList<>();
 
     private BranchLinkResult() {
     }
 
+    @SuppressWarnings("WeakerAccess")
     public String getEntityID() {
         return entity_id;
     }
@@ -120,6 +119,7 @@ public class BranchLinkResult implements Parcelable {
         return image_url;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public String getAppName() {
         return app_name;
     }
@@ -132,6 +132,7 @@ public class BranchLinkResult implements Parcelable {
         return type;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public float getScore() {
         return score;
     }
@@ -140,6 +141,7 @@ public class BranchLinkResult implements Parcelable {
         return metadata;
     }
 
+    @SuppressWarnings("WeakerAccess")
     @NonNull
     public String getRankingHint() {
         return ranking_hint;
@@ -154,6 +156,7 @@ public class BranchLinkResult implements Parcelable {
         return ranking_hint.toLowerCase().startsWith("featured");
     }
 
+    @SuppressWarnings("WeakerAccess")
     public String getRoutingMode() {
         return routing_mode;
     }
@@ -161,28 +164,30 @@ public class BranchLinkResult implements Parcelable {
     /**
      * If present, returns an Uri backed by an app-specific scheme that can
      * deep link into the app.
-     * @return uri or null
+     * @deprecated do not use. always returns null
+     * @return null
      */
-    @SuppressWarnings("WeakerAccess")
+    @Deprecated
     @Nullable
     public String getUriScheme() {
-        return TextUtils.isEmpty(uri_scheme) ? null : uri_scheme;
+        return null;
     }
 
-    @SuppressWarnings("WeakerAccess")
+    /**
+     * @deprecated always returns the empty string.
+     * @return empty string
+     */
+    @Deprecated
     @NonNull
     public String getWebLink() {
-        String webLink = web_link;
-        if (webLink == null) {
-            webLink = "https://play.google.com/store/apps/details?id=" + destination_store_id;
-        }
-        return webLink;
+        return "";
     }
 
     public String getDestinationPackageName() {
         return destination_store_id;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public String getClickTrackingUrl() {
         return click_tracking_url;
     }
@@ -191,11 +196,12 @@ public class BranchLinkResult implements Parcelable {
      * Returns the shortcut id, or null if this link does not represent an Android launcher shortcut.
      * To inspect the package, please see {@link #getDestinationPackageName()}.
      * @return id or null
+     * @deprecated this always return null
      */
-    @SuppressWarnings("WeakerAccess")
+    @Deprecated
     @Nullable
     public String getAndroidShortcutId() {
-        return TextUtils.isEmpty(android_shortcut_id) ? null : android_shortcut_id;
+        return null;
     }
 
     /**
@@ -213,6 +219,7 @@ public class BranchLinkResult implements Parcelable {
      * This method allows you to register a click event on the action, which informs Branch
      * which item was clicked, improving the rankings and personalization over time
      */
+    @SuppressWarnings("WeakerAccess")
     public void registerClickEvent() {
         if (!TextUtils.isEmpty(click_tracking_url)) {
             // Fire off an async click event
@@ -271,153 +278,33 @@ public class BranchLinkResult implements Parcelable {
      * @param context             Application context
      * @param fallbackToPlayStore If set to {@code true} fallbacks to the Google play if the app is not installed and there is no valid web url.
      * @return BranchSearchError {@link BranchSearchError} object to pass any error with complete action. Null if succeeded.
+     * @deprecated use {@link #open(Context)}
      */
+    @Deprecated
     @SuppressWarnings("UnusedReturnValue")
     @Nullable
     public BranchSearchError openContent(@NonNull Context context, boolean fallbackToPlayStore) {
+        return open(context);
+    }
+
+    /**
+     * Opens this link.
+     * @param context a context
+     * @return An error if something went wrong. Null if succeeded.
+     */
+    @Nullable
+    public BranchSearchError open(@NonNull Context context) {
         registerClickEvent();
-        boolean hasApp = Util.isAppInstalled(context, destination_store_id);
-        boolean hasPlayStore = Util.isAppInstalled(context, PLAY_STORE_PACKAGE_NAME);
-
-        // 1. Try to open the app as an Android shortcut
-        boolean success = openAppWithAndroidShortcut(context, hasApp, hasPlayStore);
-
-        // 2. Try to open the app directly with URI Scheme
-        if (!success) {
-            success = openAppWithUriScheme(context, hasApp, hasPlayStore);
+        boolean open = false;
+        for (BranchLinkHandler handler : handlers) {
+            open = handler.open(context, destination_store_id);
+            if (open) break;
         }
-
-        // 3. Try opening with the web link in app
-        if (!success) {
-            success = openAppWithWebLink(context, hasApp, hasPlayStore, true);
+        if (open) {
+            return null;
+        } else {
+            return new BranchSearchError(BranchSearchError.ERR_CODE.ROUTING_ERR_UNABLE_TO_OPEN_APP);
         }
-
-        // 4. Try opening with the web link in browser
-        if (!success) {
-            success = openAppWithWebLink(context, hasApp, hasPlayStore, false);
-        }
-
-        // 5. Fallback to the playstore
-        if (!success && fallbackToPlayStore) {
-            success = openAppWithPlayStore(context);
-        }
-
-        BranchSearchError err = null;
-        if (!success) {
-            err = new BranchSearchError(BranchSearchError.ERR_CODE.ROUTING_ERR_UNABLE_TO_OPEN_APP);
-        }
-        return err;
-    }
-
-    /**
-     * Tries to open this result as an Android shortcut, assuming it represents
-     * one and the current {@link IBranchShortcutHandler} can handle it.
-     * @param context a context
-     * @return true if succeeded
-     */
-    @SuppressWarnings("unused")
-    private boolean openAppWithAndroidShortcut(@NonNull Context context,
-                                               boolean hasApp,
-                                               boolean hasPlayStore) {
-        if (!hasApp) return false;
-        if (Build.VERSION.SDK_INT < 25) return false;
-        String id = getAndroidShortcutId();
-        if (id == null) return false;
-        IBranchShortcutHandler handler = BranchSearch.getInstance()
-                .getBranchConfiguration()
-                .getShortcutHandler();
-        return handler.launchShortcut(context, id, destination_store_id);
-    }
-
-    /**
-     * Tries to open this result with the uri scheme, if present.
-     * @param context a context
-     * @return true if succeeded
-     */
-    private boolean openAppWithUriScheme(@NonNull Context context,
-                                         boolean hasApp,
-                                         boolean hasPlayStore) {
-        try {
-            String scheme = getUriScheme();
-            if (scheme == null) return false;
-            Uri uri = Uri.parse(scheme);
-            boolean isAndroidApp = ANDROID_APP_URI_SCHEME.equals(uri.getScheme());
-            if (!hasApp && !isAndroidApp) return false;
-
-            Intent intent = new Intent(Intent.ACTION_VIEW);
-            intent.setData(uri);
-            int intentFlags = BranchSearch.getInstance()
-                    .getBranchConfiguration()
-                    .getLaunchIntentFlags();
-            intent.setFlags(intentFlags);
-            if (!isAndroidApp) {
-                // This is an app-specific URI. Enforce the package name,
-                // just in the case of conflict between multiple apps using the same
-                // scheme (we've seen this happening). This will avoid the app chooser.
-                intent.setPackage(destination_store_id);
-            } else {
-                // android-app is a special scheme defined by Android that contains
-                // the package in the URI itself. If app is not installed, the system should be
-                // free to handle this, typically by going to the play store.
-                // There's no risk of ambiguity here so no need to force package.
-                // (if we force the PS package, actually it won't even work.)
-            }
-            context.startActivity(intent);
-            return true;
-        } catch (Exception ignore) {
-            // Nothing to do
-        }
-        return false;
-    }
-
-    /**
-     * Tries to open this result with the web link.
-     * If forcePackage is true, the package is passed to the intent to avoid the app chooser.
-     * This can fail if the app does not support this link, so it is recommended to fire a
-     * second call with forcePackage set to false.
-     * @param context context
-     * @param forcePackage true to force package
-     * @return true if succeeded
-     */
-    @SuppressWarnings("StatementWithEmptyBody")
-    private boolean openAppWithWebLink(@NonNull Context context,
-                                       boolean hasApp,
-                                       boolean hasPlayStore,
-                                       boolean forcePackage) {
-        try {
-            String webLink = getWebLink();
-            if (!TextUtils.isEmpty(webLink)) {
-                Uri uri = Uri.parse(webLink);
-                Intent intent = new Intent(Intent.ACTION_VIEW);
-                intent.setData(uri);
-                int intentFlags = BranchSearch.getInstance()
-                        .getBranchConfiguration()
-                        .getLaunchIntentFlags();
-                intent.setFlags(intentFlags);
-                if (forcePackage) {
-                    boolean isPlayStore = PLAY_STORE_URI_HOST.equals(uri.getHost());
-                    if (isPlayStore && hasPlayStore) {
-                        // If play store link, instead of forcing the app package, for the play
-                        // store package, so we avoid chooser between play store and browser.
-                        intent.setPackage(PLAY_STORE_PACKAGE_NAME);
-                    } else if (!isPlayStore && hasApp) {
-                        intent.setPackage(destination_store_id);
-                    } else {
-                        // Either a PS link on a phone without PS, or a non-PS link
-                        // for an app that's not installed. Nothing to force.
-                    }
-                }
-                context.startActivity(intent);
-                return true;
-            }
-        } catch (Exception ignore) {
-            // Nothing to do
-        }
-        return false;
-    }
-
-    private boolean openAppWithPlayStore(@NonNull Context context) {
-        return Util.openAppInPlayStore(context, destination_store_id);
     }
 
     @SuppressLint("NewApi")
@@ -426,8 +313,7 @@ public class BranchLinkResult implements Parcelable {
                                            @NonNull String appName,
                                            @NonNull String appPackageName,
                                            @NonNull String appIconUrl,
-                                           @NonNull String appDeepviewExtraText,
-                                           boolean appIsInstalled) {
+                                           @NonNull String appDeepviewExtraText) {
         BranchLinkResult link = new BranchLinkResult();
         link.entity_id = Util.optString(json, LINK_ENTITY_ID_KEY);
         link.type = Util.optString(json, LINK_TYPE_KEY);
@@ -443,39 +329,38 @@ public class BranchLinkResult implements Parcelable {
         if (link.metadata == null) link.metadata = new JSONObject();
 
         link.routing_mode = Util.optString(json, LINK_ROUTING_MODE_KEY);
-        link.uri_scheme = Util.optString(json, LINK_URI_SCHEME_KEY);
-        link.web_link = Util.optString(json, LINK_WEB_LINK_KEY);
         link.destination_store_id = appPackageName;
 
         link.click_tracking_url = Util.optString(json, LINK_TRACKING_KEY);
-        link.android_shortcut_id = Util.optString(json, LINK_ANDROID_SHORTCUT_ID_KEY);
         link.icon_category = json.optString(LINK_ICON_CATEGORY, ICON_CATEGORY_OTHER);
         link.deepview_extra_text = json.optString(LINK_DEEPVIEW_EXTRA_TEXT_KEY,
                 appDeepviewExtraText);
 
-        // Now that we have parsed the JSON, filter ourselves out if needed.
-        // Remove invalid shortcuts
-        String shortcutId = link.getAndroidShortcutId();
-        if (shortcutId != null) { // Need to validate
-            Context context = BranchSearch.getInstance().getApplicationContext();
-            IBranchShortcutHandler handler = BranchSearch.getInstance()
-                    .getBranchConfiguration()
-                    .getShortcutHandler();
-            if (!handler.validateShortcut(context, shortcutId, appPackageName)) {
-                return null;
-            }
-        }
-        // If app not installed, remove non http(s)/android-app.
-        if (!appIsInstalled) {
-            boolean isWeb = !TextUtils.isEmpty(link.web_link);
-            boolean isPlayStore = link.getUriScheme() != null
-                    && link.getUriScheme().startsWith("android-app://");
-            if (!isWeb && !isPlayStore) {
-                return null;
+        JSONArray handlers = json.optJSONArray(LINK_HANDLERS);
+        if (handlers != null) {
+            for (int i = 0; i < handlers.length(); i++) {
+                try {
+                    JSONObject object = handlers.getJSONObject(i);
+                    link.handlers.add(BranchLinkHandler.from(object));
+                } catch (JSONException ignore) {
+                }
             }
         }
 
-        return link;
+        // Now that we have parsed the JSON, filter ourselves out if needed.
+        Context context = BranchSearch.getInstance().getApplicationContext();
+        boolean canHandle = false;
+        for (BranchLinkHandler handler : link.handlers) {
+            if (handler.validate(context, appPackageName)) {
+                canHandle = true;
+                break;
+            }
+        }
+        if (!canHandle) {
+            return null;
+        } else {
+            return link;
+        }
     }
 
     @Override
@@ -488,7 +373,6 @@ public class BranchLinkResult implements Parcelable {
         dest.writeString(this.entity_id);
         dest.writeString(this.type);
         dest.writeFloat(this.score);
-
         dest.writeString(this.name);
         dest.writeString(this.description);
         dest.writeString(this.image_url);
@@ -496,16 +380,12 @@ public class BranchLinkResult implements Parcelable {
         dest.writeString(this.app_icon_url);
         dest.writeString(this.ranking_hint);
         dest.writeString(this.metadata.toString());
-
         dest.writeString(this.routing_mode);
-        dest.writeString(this.uri_scheme);
-        dest.writeString(this.web_link);
         dest.writeString(this.destination_store_id);
-
         dest.writeString(this.click_tracking_url);
-        dest.writeString(this.android_shortcut_id);
         dest.writeString(this.icon_category);
         dest.writeString(this.deepview_extra_text);
+        dest.writeTypedList(this.handlers);
     }
 
 
@@ -513,7 +393,6 @@ public class BranchLinkResult implements Parcelable {
         this.entity_id = in.readString();
         this.type = in.readString();
         this.score = in.readFloat();
-
         this.name = in.readString();
         this.description = in.readString();
         this.image_url = in.readString();
@@ -525,16 +404,12 @@ public class BranchLinkResult implements Parcelable {
         } catch (JSONException e) {
             this.metadata = new JSONObject();
         }
-
         this.routing_mode = in.readString();
-        this.uri_scheme = in.readString();
-        this.web_link = in.readString();
         this.destination_store_id = in.readString();
-
         this.click_tracking_url = in.readString();
-        this.android_shortcut_id = in.readString();
         this.icon_category = in.readString();
         this.deepview_extra_text = in.readString();
+        in.readTypedList(this.handlers, BranchLinkHandler.CREATOR);
     }
 
     public static final Creator<BranchLinkResult> CREATOR = new Creator<BranchLinkResult>() {

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -381,7 +381,6 @@ public class BranchLinkResult implements Parcelable {
 
         // Now that we have parsed the JSON, filter ourselves out if needed.
         Context context = BranchSearch.getInstance().getApplicationContext();
-        boolean canHandle = false;
         for (BranchLinkHandler handler : link.handlers) {
             if (handler.validate(context, link)) {
                 return link;

--- a/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/BranchLinkResult.java
@@ -297,7 +297,9 @@ public class BranchLinkResult implements Parcelable {
         registerClickEvent();
         boolean open = false;
         for (BranchLinkHandler handler : handlers) {
-            open = handler.open(context, destination_store_id);
+            // let's validate again before opening: something might have changed.
+            open = handler.validate(context, destination_store_id)
+                    && handler.open(context, destination_store_id);
             if (open) break;
         }
         if (open) {

--- a/BranchSearchSDK/src/main/java/io/branch/search/IBranchDeepViewHandler.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IBranchDeepViewHandler.java
@@ -1,0 +1,68 @@
+package io.branch.search;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.LauncherApps;
+import android.content.pm.ShortcutInfo;
+import android.os.Build;
+import android.os.Process;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+
+import java.util.List;
+
+/**
+ * Handles {@link BranchDeepViewFragment} launch.
+ */
+public interface IBranchDeepViewHandler {
+
+    /**
+     * Launches the given deepview.
+     * @param context context
+     * @param fragment fragment
+     * @return true if launched correctly
+     */
+    boolean launchDeepView(@NonNull Context context, @NonNull BranchDeepViewFragment fragment);
+
+    /**
+     * The default handler.
+     */
+    IBranchDeepViewHandler DEFAULT = new IBranchDeepViewHandler() {
+
+        @Override
+        public boolean launchDeepView(@NonNull Context context, @NonNull BranchDeepViewFragment fragment) {
+            Activity activity = findActivity(context);
+            if (activity == null) {
+                return false;
+            } else if (activity instanceof FragmentActivity) {
+                FragmentManager manager = ((FragmentActivity) activity).getSupportFragmentManager();
+                fragment.getInstance().show(manager, BranchDeepViewFragment.TAG);
+            } else {
+                // Legacy version of activities that do not extend FragmentActivity.
+                android.app.FragmentManager manager = activity.getFragmentManager();
+                fragment.getLegacyInstance().show(manager, BranchDeepViewFragment.TAG);
+            }
+            return false;
+        }
+
+
+        @Nullable
+        private Activity findActivity(@NonNull Context context) {
+            if (context instanceof Activity) {
+                return (Activity) context;
+            } else if (context instanceof ContextWrapper) {
+                Context parent = ((ContextWrapper) context).getBaseContext();
+                if (parent == null || parent == context) {
+                    return null;
+                } else {
+                    return findActivity(parent);
+                }
+            } else {
+                return null;
+            }
+        }
+    };
+}

--- a/BranchSearchSDK/src/main/java/io/branch/search/IURLConnectionEvents.java
+++ b/BranchSearchSDK/src/main/java/io/branch/search/IURLConnectionEvents.java
@@ -7,6 +7,7 @@ import org.json.JSONObject;
 /**
  * URLConnection Event Interface.
  */
+// TODO should not be public.
 public interface IURLConnectionEvents {
     void onResult(@NonNull JSONObject response);
 }

--- a/README.md
+++ b/README.md
@@ -247,9 +247,9 @@ The BranchSearchResult object is returned to you from a successful query and con
 
 | Method | Return Type | Description |
 | - | - | - |
-| getBranchSearchRequest | `BranchSearchRequest` | The original search request of format `BranchSearchRequest` that triggered this specific set of results. Note that you can reference the original query by calling `getQuery()` on this object. |
-| getCorrectedQuery | String | If this field is non-null, it will represent the spell-corrected query that was actually used to search. Recommend that you show feedback to user such as "Showing results for + <corrected query>" |
-| getResults | List<`BranchAppResult`> | A list of `BranchAppResult` objects representing the application results matched for the search request. Attached to each object is also the deep link list to show in this group. |
+| `getBranchSearchRequest()` | `BranchSearchRequest` | The original search request of format `BranchSearchRequest` that triggered this specific set of results. Note that you can reference the original query by calling `getQuery()` on this object. |
+| `getCorrectedQuery()` | `String` | If this field is non-null, it will represent the spell-corrected query that was actually used to search. Recommend that you show feedback to user such as "Showing results for + <corrected query>" |
+| `getResults()` | `List<BranchAppResult>` | A list of `BranchAppResult` objects representing the application results matched for the search request. Attached to each object is also the deep link list to show in this group. |
 
 ### BranchAppResult class
 
@@ -257,14 +257,11 @@ Branch will return to you a list of relevants apps for each query, similar to if
 
 | Method | Return Type | Description |
 | - | - | - |
-| getAppName | String | Gets the name of the app for display |
-| getPackageName | String | Gets the package name of the app |
-| getAppIconUrl | String | Gets the URL of the app icon for display |
-| getDeepLinks | List | Gets the list of `BranchLinkResult` objects for display |
-| | | |
-| openSearchDeepLink(Context, Boolean fallbackToPlayStore) | BranchSearchError | The method to trigger when a user clicks on the header. This will attempt to trigger the search deep link to continue the user query in the app. Some apps dox not support this, and the fallback will trigger openApp. |
-| isSearchDeepLinkAvailable() | boolean | This method will return true if the search deep link is available. This can be used to change the UI based on its presence. |
-| openApp(Context, boolean fallbackToPlayStore) | BranchSearchError | If you just want to open the app without searching, use this method. Specify as argument whether you want the user to go to the Play Store when app is not installed |
+| `getAppName()` | `String` | Gets the name of the app for display |
+| `getPackageName()` | `String` | Gets the package name of the app |
+| `getAppIconUrl()` | `String` | Gets the URL of the app icon for display |
+| `getDeepLinks()` | `List` | Gets the list of `BranchLinkResult` objects for display |
+| `openApp(Context, boolean fallbackToPlayStore)` | `BranchSearchError` | If you just want to open the app without searching, use this method. Specify as argument whether you want the user to go to the Play Store when app is not installed |
 
 
 #### BranchLinkResult class
@@ -273,15 +270,11 @@ Branch will also return relevant content to the user query. These are deep links
 
 | Method | Return Type | Description |
 | - | - | - |
-| getName | String | Gets the title of the content for display |
-| getDescription | String | Gets the description of the content for display |
-| getImageUrl | String | Gets the URL of the content image for display |
-| isAd | boolean | Is this link an advertisement -- e.g. a sponsored result | 
-| | | |
-| openContent(Context, boolean fallbackToPlayStore) | BranchSearchError | Branch is great at deep link routing, so we wanted to abstract away this complexity from you. When a user taps on an action, you simply need to call `completeAction()` to trigger the user to be routed to the content or website. |
-| openDeepView(FragmentManager) | BranchSearchError | Opens the link into a [Branch Deepview](https://branch.io/deepviews/). The content preview will be rendered inside a in-app web view with the option to download the app from the play store. |
-| registerClickEvent() | none | If you decide to handle routing on your own with the URI scheme / web link included in the link result, please call this method when the user taps. _This is not required if you use openContent or openDeepView_ |
-
+| `getName()` | `String` | Gets the title of the content for display |
+| `getDescription()` | `String` | Gets the description of the content for display |
+| `getImageUrl()` | `String` | Gets the URL of the content image for display |
+| `isAd()` | `boolean` | Is this link an advertisement -- e.g. a sponsored result |
+| `open(Context)` | `BranchSearchError` | Branch is great at deep link routing, so we wanted to abstract away this complexity from you. When a user taps on an action, you simply need to call `open()` to trigger the user to be routed to the content or website. |
 
 ## Handling errors with `BranchSearchError`
 


### PR DESCRIPTION
Introduces link handling v2. The v2 concepts are wrapped in the `BranchLinkHandler` class. Both opening methods and scoping rules are actually instances of a `BranchLinkHandler`.

- Add `view_intent` handler: opens `Intent.ACTION_VIEW` for the given data URI. Server can specify a package to be enforced and extras.
- Add `launch_intent` handler: opens intents with `PackageManager.getLaunchIntentForPackage()`. Server can specify extras.
- Add `intent` handler: opens a custom intent for the given action (e.g. actions other than `Intent.ACTION_VIEW`). Optionally accepts a data URI and extras.
- Add `shortcut` handler: opens android shortcuts if possible
- Add `test_installed` handler: if app is installed, triggers its own child handlers (if not, fails)
- Add `test_not_installed` handler: if app is not installed, triggers its own child handlers (if not, fails)
- Add `deep_view` handler: a handler that opens the deepview fragment and passes child handlers to it, so they will be triggered when the CTA button is clicked

How these handlers work with the rest of the SDK:
- New `BranchLinkResult.open(Context)` to open the link with handlers, replacing the old open API
- Rewritten link filtering by using handlers: we'll filter out links if no link handlers can open it
- Add `BranchConfiguration.setDeepViewHandler()`: the `deep_view` mentioned above only works when people give us an Activity context, because we need a fragment manager. If they want to pass another kind of context, they can still try to open the deepview on their own by registering this interface.
- Deprecate `openContent(Context, boolean)`, `getUriScheme()`, `getWebLink()`, `getAndroidShortcutId()`, `openDeepView(FragmentManager)`, `openDeepView(android.app.FragmentManager)`

An example of how requests will look like:

```
{
  "name": "My link",
  "description": "Link description",
  "linking": [
    {
      "@type": "view_intent",
      "data": "https://custom.url1"
    },
    {
      "@type": "view_intent",
      "data": "custom://custom.uri.scheme"
    },
    {
      "@type": "view_intent",
      "data": "custom://custom.uri.scheme2"
    },
    {
      "@type": "launch_intent",
      "package": "com.ubercab"
    }
  ]
}
```